### PR TITLE
CI Coq build fails: '-R . Hello' grafts opam stdlib under Hello prefix and breaks Corelib.Prelude lookup (closes #8)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build test clean
 
 build:
-	rocq compile -R theories Hello theories/Hello.v
+	rocq compile -Q theories Hello theories/Hello.v
 
 test: build
 

--- a/_RocqProject
+++ b/_RocqProject
@@ -1,3 +1,3 @@
--R theories Hello
+-Q theories Hello
 
 theories/Hello.v


### PR DESCRIPTION
Fixes #8.

Switch from `-R` (recursive) to `-Q` (qualified) in `_RocqProject` and the `Makefile` so the opam local switch can never be grafted into the `Hello` logical namespace.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Replace -R with -Q in _RocqProject and Makefile to prevent namespace grafting <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->