### PR TITLE
Publish rocq/ocaml docker image to ghcr.io and use it from CI to skip install (closes #30)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,12 @@ on:
 jobs:
   verify:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/rhencke/orly:latest
 
     steps:
       - uses: actions/checkout@v4
 
+      - name: Pull or build container image
+        run: docker pull ghcr.io/rhencke/orly:latest || docker build -t ghcr.io/rhencke/orly:latest .
+
       - name: Verify proofs
-        run: opam exec -- make test
+        run: docker run --rm -v "$PWD:/workspace" ghcr.io/rhencke/orly:latest opam exec -- make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,18 +8,11 @@ on:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/rhencke/orly:latest
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up OCaml
-        uses: ocaml/setup-ocaml@v3
-        with:
-          ocaml-compiler: "4.14"
-          cache: true
-
-      - name: Install Rocq
-        run: opam install -y rocq-prover
 
       - name: Verify proofs
         run: opam exec -- make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,4 @@ jobs:
         run: docker pull ghcr.io/rhencke/orly:latest || docker build -t ghcr.io/rhencke/orly:latest .
 
       - name: Verify proofs
-        run: docker run --rm -u "$(id -u):$(id -g)" -e HOME=/home/opam -v "$PWD:/workspace" -w /workspace ghcr.io/rhencke/orly:latest opam exec -- make test
+        run: docker run --rm -v "$PWD:/src:ro" ghcr.io/rhencke/orly:latest sh -c "cp -r /src /tmp/work && cd /tmp/work && opam exec -- make test"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,4 @@ jobs:
         run: docker pull ghcr.io/rhencke/orly:latest || docker build -t ghcr.io/rhencke/orly:latest .
 
       - name: Verify proofs
-        run: docker run --rm -v "$PWD:/workspace" ghcr.io/rhencke/orly:latest opam exec -- make test
+        run: docker run --rm -u "$(id -u):$(id -g)" -e HOME=/home/opam -v "$PWD:/workspace" -w /workspace ghcr.io/rhencke/orly:latest opam exec -- make test

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,33 @@
+name: Publish image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/rhencke/orly:latest
+            ghcr.io/rhencke/orly:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ RUN sudo apt-get update \
     && sudo apt-get install -y --no-install-recommends \
         make \
         build-essential \
+        pkg-config \
+        libgmp-dev \
+        linux-libc-dev \
     && sudo rm -rf /var/lib/apt/lists/*
 
 # Install Rocq and clean up the opam cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ocaml/opam:debian-12-ocaml-4.14
+
+# Install system build tools
+RUN sudo apt-get update \
+    && sudo apt-get install -y --no-install-recommends \
+        make \
+        build-essential \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+# Install Rocq and clean up the opam cache
+RUN opam install -y rocq-prover \
+    && opam clean --all
+
+WORKDIR /workspace
+USER opam


### PR DESCRIPTION
Fixes #30.

Bake the OCaml 4.14 + Rocq toolchain into a Docker image published to ghcr.io, then swap CI to run inside it — no more cold-installing Rocq on every cache miss. Adds a Dockerfile, a publish-image workflow, and updates ci.yml to use the container.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Add Dockerfile with OCaml 4.14 and Rocq toolchain <!-- type:spec -->
- [x] Add publish-image workflow to build and push to ghcr.io <!-- type:spec -->
- [x] Update CI to run inside the published container image <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->