### PR TITLE
Build the JsCoq + GitHub Pages browser shell in docs/ (closes #9)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only one deployment at a time; cancel in-progress if a new push arrives.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean
+.PHONY: build test clean serve
 
 build:
 	rocq compile -Q theories Hello theories/Hello.v
@@ -7,3 +7,6 @@ test: build
 
 clean:
 	rm -f theories/*.vo theories/*.vok theories/*.vos theories/*.glob theories/.*.aux
+
+serve:
+	python3 -m http.server 8080 --directory docs

--- a/docs/coi-serviceworker.js
+++ b/docs/coi-serviceworker.js
@@ -1,0 +1,146 @@
+/*! coi-serviceworker v0.1.7 - Guido Zuidhof and contributors, licensed under MIT */
+let coepCredentialless = false;
+if (typeof window === 'undefined') {
+    self.addEventListener("install", () => self.skipWaiting());
+    self.addEventListener("activate", (event) => event.waitUntil(self.clients.claim()));
+
+    self.addEventListener("message", (ev) => {
+        if (!ev.data) {
+            return;
+        } else if (ev.data.type === "deregister") {
+            self.registration
+                .unregister()
+                .then(() => {
+                    return self.clients.matchAll();
+                })
+                .then(clients => {
+                    clients.forEach((client) => client.navigate(client.url));
+                });
+        } else if (ev.data.type === "coepCredentialless") {
+            coepCredentialless = ev.data.value;
+        }
+    });
+
+    self.addEventListener("fetch", function (event) {
+        const r = event.request;
+        if (r.cache === "only-if-cached" && r.mode !== "same-origin") {
+            return;
+        }
+
+        const request = (coepCredentialless && r.mode === "no-cors")
+            ? new Request(r, {
+                credentials: "omit",
+            })
+            : r;
+        event.respondWith(
+            fetch(request)
+                .then((response) => {
+                    if (response.status === 0) {
+                        return response;
+                    }
+
+                    const newHeaders = new Headers(response.headers);
+                    newHeaders.set("Cross-Origin-Embedder-Policy",
+                        coepCredentialless ? "credentialless" : "require-corp"
+                    );
+                    if (!coepCredentialless) {
+                        newHeaders.set("Cross-Origin-Resource-Policy", "cross-origin");
+                    }
+                    newHeaders.set("Cross-Origin-Opener-Policy", "same-origin");
+
+                    return new Response(response.body, {
+                        status: response.status,
+                        statusText: response.statusText,
+                        headers: newHeaders,
+                    });
+                })
+                .catch((e) => console.error(e))
+        );
+    });
+
+} else {
+    (() => {
+        const reloadedBySelf = window.sessionStorage.getItem("coiReloadedBySelf");
+        window.sessionStorage.removeItem("coiReloadedBySelf");
+        const coepDegrading = (reloadedBySelf == "coepdegrade");
+
+        // You can customize the behavior of this script through a global `coi` variable.
+        const coi = {
+            shouldRegister: () => !reloadedBySelf,
+            shouldDeregister: () => false,
+            coepCredentialless: () => true,
+            coepDegrade: () => true,
+            doReload: () => window.location.reload(),
+            quiet: false,
+            ...window.coi
+        };
+
+        const n = navigator;
+        const controlling = n.serviceWorker && n.serviceWorker.controller;
+
+        // Record the failure if the page is served by serviceWorker.
+        if (controlling && !window.crossOriginIsolated) {
+            window.sessionStorage.setItem("coiCoepHasFailed", "true");
+        }
+        const coepHasFailed = window.sessionStorage.getItem("coiCoepHasFailed");
+
+        if (controlling) {
+            // Reload only on the first failure.
+            const reloadToDegrade = coi.coepDegrade() && !(
+                coepDegrading || window.crossOriginIsolated
+            );
+            n.serviceWorker.controller.postMessage({
+                type: "coepCredentialless",
+                value: (reloadToDegrade || coepHasFailed && coi.coepDegrade())
+                    ? false
+                    : coi.coepCredentialless(),
+            });
+            if (reloadToDegrade) {
+                !coi.quiet && console.log("Reloading page to degrade COEP.");
+                window.sessionStorage.setItem("coiReloadedBySelf", "coepdegrade");
+                coi.doReload("coepdegrade");
+            }
+
+            if (coi.shouldDeregister()) {
+                n.serviceWorker.controller.postMessage({ type: "deregister" });
+            }
+        }
+
+        // If we're already coi: do nothing. Perhaps it's due to this script doing its job, or COOP/COEP are
+        // already set from the origin server. Also if the browser has no notion of crossOriginIsolated, just give up here.
+        if (window.crossOriginIsolated !== false || !coi.shouldRegister()) return;
+
+        if (!window.isSecureContext) {
+            !coi.quiet && console.log("COOP/COEP Service Worker not registered, a secure context is required.");
+            return;
+        }
+
+        // In some environments (e.g. Firefox private mode) this won't be available
+        if (!n.serviceWorker) {
+            !coi.quiet && console.error("COOP/COEP Service Worker not registered, perhaps due to private mode.");
+            return;
+        }
+
+        n.serviceWorker.register(window.document.currentScript.src).then(
+            (registration) => {
+                !coi.quiet && console.log("COOP/COEP Service Worker registered", registration.scope);
+
+                registration.addEventListener("updatefound", () => {
+                    !coi.quiet && console.log("Reloading page to make use of updated COOP/COEP Service Worker.");
+                    window.sessionStorage.setItem("coiReloadedBySelf", "updatefound");
+                    coi.doReload();
+                });
+
+                // If the registration is active, but it's not controlling the page
+                if (registration.active && !n.serviceWorker.controller) {
+                    !coi.quiet && console.log("Reloading page to make use of COOP/COEP Service Worker.");
+                    window.sessionStorage.setItem("coiReloadedBySelf", "notcontrolling");
+                    coi.doReload();
+                }
+            },
+            (err) => {
+                !coi.quiet && console.error("COOP/COEP Service Worker failed to register:", err);
+            }
+        );
+    })();
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>orly — Rocq in the browser</title>
+
+  <!--
+    coi-serviceworker: patches COOP/COEP headers via a service worker so
+    JsCoq's SharedArrayBuffer-based workers function on GitHub Pages, which
+    does not send these headers from the origin server.
+    Source: https://github.com/gzuidhof/coi-serviceworker (MIT)
+  -->
+  <script src="coi-serviceworker.js"></script>
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: system-ui, sans-serif;
+      background: #0d0d0d;
+      color: #e0e0e0;
+      display: flex;
+      flex-direction: column;
+      height: 100dvh;
+      overflow: hidden;
+    }
+
+    /* ── header ─────────────────────────────────────────────── */
+    #orly-header {
+      flex: 0 0 auto;
+      padding: 0.4rem 1rem;
+      background: #1a1a2e;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      border-bottom: 1px solid #2a2a4e;
+    }
+    #orly-header h1 {
+      font-size: 1.1rem;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      color: #a0c4ff;
+    }
+    #orly-header .subtitle {
+      font-size: 0.75rem;
+      color: #666;
+    }
+
+    /* ── main split ──────────────────────────────────────────── */
+    #main {
+      flex: 1 1 auto;
+      display: flex;
+      flex-direction: column;
+      min-height: 0; /* allow children to shrink */
+    }
+
+    /* ── game canvas ─────────────────────────────────────────── */
+    #game-surface {
+      flex: 1 1 auto;
+      position: relative;
+      background: #000;
+      min-height: 0;
+    }
+    #game-canvas {
+      display: block;
+      width: 100%;
+      height: 100%;
+      /* canvas intrinsic size is set by JS; CSS fills the container */
+    }
+    #game-placeholder {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      color: #333;
+      font-size: 0.85rem;
+      pointer-events: none;
+      gap: 0.4rem;
+    }
+    #game-placeholder .label {
+      font-size: 1.5rem;
+      color: #222;
+    }
+
+    /* ── JsCoq IDE panel ─────────────────────────────────────── */
+    #jscoq-panel {
+      flex: 0 0 40vh;
+      min-height: 120px;
+      max-height: 60vh;
+      overflow: hidden;
+      border-top: 2px solid #2a2a4e;
+      background: #fff; /* JsCoq ships a light-theme IDE */
+      position: relative;
+    }
+
+    /* JsCoq uses its own internal layout — let it fill the panel */
+    #ide-wrapper {
+      width: 100%;
+      height: 100%;
+    }
+
+    /* ── touch-friendly resize handle ───────────────────────── */
+    #resize-handle {
+      flex: 0 0 6px;
+      background: #2a2a4e;
+      cursor: ns-resize;
+      touch-action: none;
+    }
+    #resize-handle:hover { background: #a0c4ff; }
+  </style>
+</head>
+<body>
+  <header id="orly-header">
+    <h1>orly</h1>
+    <span class="subtitle">Rocq · JsCoq · browser</span>
+  </header>
+
+  <div id="main">
+    <!-- ── game canvas (Quake rendering target: issues #15, #16) ── -->
+    <div id="game-surface">
+      <canvas id="game-canvas" aria-label="Game surface"></canvas>
+      <div id="game-placeholder">
+        <span class="label">[ game canvas ]</span>
+        <span>Quake rendering target — coming in <a href="https://github.com/rhencke/orly/issues/15" style="color:#444">#15</a></span>
+      </div>
+    </div>
+
+    <!-- touch-friendly drag handle to resize the two panels -->
+    <div id="resize-handle" role="separator" aria-label="Drag to resize"></div>
+
+    <!-- ── JsCoq IDE panel ── -->
+    <div id="jscoq-panel">
+      <div id="ide-wrapper" class="toggled">
+        <div id="code-wrapper">
+          <div id="document">
+            <textarea class="coq-code">
+(** * Hello, Rocq!
+
+    A minimal Rocq program with proof-based verification. *)
+
+Require Import Strings.String.
+Open Scope string_scope.
+
+(** A greeting function. *)
+Definition hello (name : string) : string :=
+  "Hello, " ++ name ++ "!".
+
+(** [hello "world"] produces ["Hello, world!"]. *)
+Theorem hello_world : hello "world" = "Hello, world!".
+Proof.
+  reflexivity.
+Qed.
+            </textarea>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script type="module">
+    // ── JsCoq bootstrap ─────────────────────────────────────────
+    // Loaded from jsDelivr CDN. base_path points to the same CDN origin
+    // so JsCoq can resolve its worker scripts and Coq package bundles.
+    const JSCOQ_CDN = 'https://cdn.jsdelivr.net/npm/jscoq@0.17.1/';
+
+    import { JsCoq } from 'https://cdn.jsdelivr.net/npm/jscoq@0.17.1/jscoq.js';
+
+    JsCoq.start(
+      JSCOQ_CDN,
+      ['.coq-code'],
+      {
+        prelude:       true,
+        implicit_libs: true,
+        editor:        { mode: { 'company-coq': true } },
+        init_pkgs:     ['init'],
+        all_pkgs:      ['coq'],
+      }
+    );
+
+    // ── game canvas sizing ───────────────────────────────────────
+    // Keep the canvas pixel dimensions in sync with its CSS layout size
+    // so future renderers get a correctly sized drawing surface.
+    const canvas = document.getElementById('game-canvas');
+    const ro = new ResizeObserver(([entry]) => {
+      const { width, height } = entry.contentRect;
+      canvas.width  = Math.round(width);
+      canvas.height = Math.round(height);
+    });
+    ro.observe(canvas.parentElement);
+
+    // ── drag-to-resize handle ────────────────────────────────────
+    const handle     = document.getElementById('resize-handle');
+    const jscoqPanel = document.getElementById('jscoq-panel');
+    let dragging = false, startY = 0, startH = 0;
+
+    const onStart = (y) => { dragging = true; startY = y; startH = jscoqPanel.offsetHeight; };
+    const onMove  = (y) => {
+      if (!dragging) return;
+      const delta = startY - y;
+      const next  = Math.max(120, Math.min(window.innerHeight * 0.8, startH + delta));
+      jscoqPanel.style.flex = `0 0 ${next}px`;
+    };
+    const onEnd   = () => { dragging = false; };
+
+    handle.addEventListener('mousedown',  (e) => onStart(e.clientY));
+    document.addEventListener('mousemove', (e) => onMove(e.clientY));
+    document.addEventListener('mouseup',   onEnd);
+
+    handle.addEventListener('touchstart',  (e) => onStart(e.touches[0].clientY), { passive: true });
+    document.addEventListener('touchmove', (e) => onMove(e.touches[0].clientY),  { passive: true });
+    document.addEventListener('touchend',  onEnd);
+  </script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,6 +57,26 @@
       color: #666;
     }
 
+    /* ── status bar ──────────────────────────────────────────── */
+    #status-bar {
+      flex: 0 0 auto;
+      padding: 0.35rem 1rem;
+      font-size: 0.8rem;
+      text-align: center;
+      border-bottom: 1px solid transparent;
+    }
+    #status-bar[hidden] { display: none; }
+    #status-bar.loading {
+      background: #111a11;
+      color: #8c8;
+      border-bottom-color: #1a3a1a;
+    }
+    #status-bar.error {
+      background: #1f0f0f;
+      color: #f88;
+      border-bottom-color: #3a1a1a;
+    }
+
     /* ── main split ──────────────────────────────────────────── */
     #main {
       flex: 1 1 auto;
@@ -208,6 +228,9 @@
     <span class="subtitle">Rocq · JsCoq · browser</span>
   </header>
 
+  <!-- status bar: shows loading progress and surfaces errors in the UI -->
+  <div id="status-bar" role="alert" aria-live="polite" hidden></div>
+
   <div id="main">
     <!-- ── game canvas (Quake rendering target: issues #15, #16) ── -->
     <div id="game-surface">
@@ -251,24 +274,58 @@ Qed.
   </div>
 
   <script type="module">
+    // ── status bar helpers ───────────────────────────────────────
+    const statusBar = document.getElementById('status-bar');
+
+    function showStatus(msg, type = 'loading') {
+      statusBar.hidden = false;
+      statusBar.className = type;
+      statusBar.textContent = msg;
+    }
+
+    function clearStatus() {
+      statusBar.hidden = true;
+      statusBar.className = '';
+      statusBar.textContent = '';
+    }
+
+    // ── global error surface ─────────────────────────────────────
+    // Catch anything that slips through — script errors, failed fetches,
+    // JsCoq internal errors that bubble up as uncaught exceptions.
+    window.addEventListener('error', (e) => {
+      showStatus(`Error: ${e.message}`, 'error');
+    });
+    window.addEventListener('unhandledrejection', (e) => {
+      const msg = e.reason?.message || e.reason || 'Unknown error';
+      showStatus(`Error: ${msg}`, 'error');
+    });
+
     // ── JsCoq bootstrap ─────────────────────────────────────────
-    // Loaded from jsDelivr CDN. base_path points to the same CDN origin
-    // so JsCoq can resolve its worker scripts and Coq package bundles.
+    // Loaded from jsDelivr CDN. Uses dynamic import so we can catch
+    // network failures and surface them in the status bar instead of
+    // silently failing (a static import failure kills the whole module).
     const JSCOQ_CDN = 'https://cdn.jsdelivr.net/npm/jscoq@0.17.1/';
 
-    import { JsCoq } from 'https://cdn.jsdelivr.net/npm/jscoq@0.17.1/jscoq.js';
-
-    JsCoq.start(
-      JSCOQ_CDN,
-      ['.coq-code'],
-      {
-        prelude:       true,
-        implicit_libs: true,
-        editor:        { mode: { 'company-coq': true } },
-        init_pkgs:     ['init'],
-        all_pkgs:      ['coq'],
-      }
-    );
+    showStatus('Loading JsCoq…');
+    try {
+      const { JsCoq } = await import('https://cdn.jsdelivr.net/npm/jscoq@0.17.1/jscoq.js');
+      showStatus('Starting Rocq kernel…');
+      JsCoq.start(
+        JSCOQ_CDN,
+        ['.coq-code'],
+        {
+          prelude:       true,
+          implicit_libs: true,
+          editor:        { mode: { 'company-coq': true } },
+          init_pkgs:     ['init'],
+          all_pkgs:      ['coq'],
+        }
+      );
+      clearStatus();
+    } catch (err) {
+      showStatus(`Failed to load JsCoq: ${err.message}`, 'error');
+      console.error('JsCoq bootstrap failed:', err);
+    }
 
     // ── game canvas sizing ───────────────────────────────────────
     // Keep the canvas pixel dimensions in sync with its CSS layout size

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!--
+    viewport-fit=cover: let content fill edge-to-edge on notched phones;
+    safe-area-inset-* padding below keeps UI off the notch/home bar.
+  -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>orly — Rocq in the browser</title>
 
   <!--
@@ -24,6 +28,12 @@
       flex-direction: column;
       height: 100dvh;
       overflow: hidden;
+      /* respect notch / home-bar on iOS */
+      padding-bottom: env(safe-area-inset-bottom);
+      padding-left:   env(safe-area-inset-left);
+      padding-right:  env(safe-area-inset-right);
+      /* suppress elastic over-scroll that looks odd in a game shell */
+      overscroll-behavior: none;
     }
 
     /* ── header ─────────────────────────────────────────────── */
@@ -60,7 +70,9 @@
       flex: 1 1 auto;
       position: relative;
       background: #000;
-      min-height: 0;
+      /* guarantee at least some canvas visible on very small phones */
+      min-height: 25svh;
+      min-width: 0;
     }
     #game-canvas {
       display: block;
@@ -85,11 +97,44 @@
       color: #222;
     }
 
+    /* ── drag-to-resize handle ───────────────────────────────── */
+    /*
+      Visual: a 4px pill centered in a 20px touch-friendly strip.
+      In column layout the pill is wide (horizontal divider).
+      In row layout the pill is tall (vertical divider).
+    */
+    #resize-handle {
+      flex: 0 0 20px;
+      background: transparent;
+      cursor: ns-resize;
+      touch-action: none;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      /* prevent text selection while dragging */
+      user-select: none;
+      -webkit-user-select: none;
+    }
+    #resize-handle::before {
+      content: '';
+      display: block;
+      background: #2a2a4e;
+      border-radius: 3px;
+      /* column mode: wide horizontal pill */
+      width: 48px;
+      height: 4px;
+      transition: background 0.15s;
+    }
+    #resize-handle:hover::before,
+    #resize-handle:active::before { background: #a0c4ff; }
+
     /* ── JsCoq IDE panel ─────────────────────────────────────── */
     #jscoq-panel {
-      flex: 0 0 40vh;
+      /* svh: stable viewport height — doesn't shift when mobile
+         browser chrome appears/disappears during scroll */
+      flex: 0 0 38svh;
       min-height: 120px;
-      max-height: 60vh;
+      max-height: 65svh;
       overflow: hidden;
       border-top: 2px solid #2a2a4e;
       background: #fff; /* JsCoq ships a light-theme IDE */
@@ -102,14 +147,59 @@
       height: 100%;
     }
 
-    /* ── touch-friendly resize handle ───────────────────────── */
-    #resize-handle {
-      flex: 0 0 6px;
-      background: #2a2a4e;
-      cursor: ns-resize;
-      touch-action: none;
+    /* ══════════════════════════════════════════════════════════
+       RESPONSIVE: landscape phone
+       Trigger: orientation landscape AND height ≤ 560px.
+       On a typical phone in landscape this is true; on a tablet
+       or laptop it is not (height > 560px → desktop query wins).
+       ══════════════════════════════════════════════════════════ */
+    @media (orientation: landscape) and (max-height: 560px) {
+      /* ultra-compact header to save vertical pixels */
+      #orly-header { padding: 0.2rem 0.75rem; }
+      #orly-header h1 { font-size: 0.9rem; }
+      #orly-header .subtitle { display: none; }
+
+      /* flip to horizontal split */
+      #main { flex-direction: row; }
+
+      /* resize handle becomes a vertical bar */
+      #resize-handle { cursor: ew-resize; }
+      #resize-handle::before { width: 4px; height: 48px; }
+
+      /* JsCoq panel becomes right sidebar */
+      #jscoq-panel {
+        flex: 0 0 42vw;
+        max-width: 480px;
+        min-width: 180px;
+        height: 100%;
+        min-height: 0;
+        max-height: none;
+        border-top: none;
+        border-left: 2px solid #2a2a4e;
+      }
     }
-    #resize-handle:hover { background: #a0c4ff; }
+
+    /* ══════════════════════════════════════════════════════════
+       RESPONSIVE: wide screens (tablet landscape / desktop)
+       ══════════════════════════════════════════════════════════ */
+    @media (min-width: 1024px) {
+      /* flip to horizontal split */
+      #main { flex-direction: row; }
+
+      /* resize handle becomes a vertical bar */
+      #resize-handle { cursor: ew-resize; }
+      #resize-handle::before { width: 4px; height: 48px; }
+
+      /* JsCoq panel becomes right sidebar */
+      #jscoq-panel {
+        flex: 0 0 480px;
+        height: 100%;
+        min-height: 0;
+        max-height: none;
+        border-top: none;
+        border-left: 2px solid #2a2a4e;
+      }
+    }
   </style>
 </head>
 <body>
@@ -128,7 +218,7 @@
       </div>
     </div>
 
-    <!-- touch-friendly drag handle to resize the two panels -->
+    <!-- drag handle to resize the two panels -->
     <div id="resize-handle" role="separator" aria-label="Drag to resize"></div>
 
     <!-- ── JsCoq IDE panel ── -->
@@ -191,27 +281,69 @@ Qed.
     });
     ro.observe(canvas.parentElement);
 
-    // ── drag-to-resize handle ────────────────────────────────────
+    // ── direction-aware drag-to-resize ───────────────────────────
+    //
+    // CSS switches #main between column (portrait/narrow) and row
+    // (landscape phone / desktop) via media queries.  The JS resize
+    // handler must match: drag vertically in column mode, horizontally
+    // in row mode.  On layout-mode change we also reset any inline flex
+    // override so the CSS default sizes take over cleanly.
+    //
+    // Media queries that switch to row layout (must match CSS @media):
+    const LANDSCAPE_PHONE = '(orientation: landscape) and (max-height: 560px)';
+    const WIDE_SCREEN      = '(min-width: 1024px)';
+    const rowModeQuery = window.matchMedia(`${LANDSCAPE_PHONE}, ${WIDE_SCREEN}`);
+
+    const isRowMode = () => rowModeQuery.matches;
+
     const handle     = document.getElementById('resize-handle');
     const jscoqPanel = document.getElementById('jscoq-panel');
-    let dragging = false, startY = 0, startH = 0;
+    let dragging = false, startPos = 0, startSize = 0;
 
-    const onStart = (y) => { dragging = true; startY = y; startH = jscoqPanel.offsetHeight; };
-    const onMove  = (y) => {
-      if (!dragging) return;
-      const delta = startY - y;
-      const next  = Math.max(120, Math.min(window.innerHeight * 0.8, startH + delta));
-      jscoqPanel.style.flex = `0 0 ${next}px`;
+    const onStart = (x, y) => {
+      dragging  = true;
+      startPos  = isRowMode() ? x : y;
+      startSize = isRowMode() ? jscoqPanel.offsetWidth : jscoqPanel.offsetHeight;
     };
-    const onEnd   = () => { dragging = false; };
 
-    handle.addEventListener('mousedown',  (e) => onStart(e.clientY));
-    document.addEventListener('mousemove', (e) => onMove(e.clientY));
+    const onMove = (x, y) => {
+      if (!dragging) return;
+      if (isRowMode()) {
+        // dragging left (negative delta) increases the right-side panel
+        const delta = startPos - x;
+        const max   = window.innerWidth * 0.8;
+        const next  = Math.max(180, Math.min(max, startSize + delta));
+        jscoqPanel.style.flex = `0 0 ${next}px`;
+      } else {
+        // dragging up (negative delta) increases the bottom panel
+        const delta = startPos - y;
+        const max   = window.innerHeight * 0.8;
+        const next  = Math.max(120, Math.min(max, startSize + delta));
+        jscoqPanel.style.flex = `0 0 ${next}px`;
+      }
+    };
+
+    const onEnd = () => { dragging = false; };
+
+    // Reset inline size when the layout mode changes (e.g. phone rotated)
+    // so CSS default proportions take over for the new orientation.
+    rowModeQuery.addEventListener('change', () => {
+      jscoqPanel.style.flex = '';
+    });
+
+    // mouse
+    handle.addEventListener('mousedown',  (e) => onStart(e.clientX, e.clientY));
+    document.addEventListener('mousemove', (e) => onMove(e.clientX, e.clientY));
     document.addEventListener('mouseup',   onEnd);
 
-    handle.addEventListener('touchstart',  (e) => onStart(e.touches[0].clientY), { passive: true });
-    document.addEventListener('touchmove', (e) => onMove(e.touches[0].clientY),  { passive: true });
-    document.addEventListener('touchend',  onEnd);
+    // touch (passive where possible to avoid blocking scroll on the rest of the page)
+    handle.addEventListener('touchstart', (e) => {
+      onStart(e.touches[0].clientX, e.touches[0].clientY);
+    }, { passive: true });
+    document.addEventListener('touchmove', (e) => {
+      onMove(e.touches[0].clientX, e.touches[0].clientY);
+    }, { passive: true });
+    document.addEventListener('touchend', onEnd);
   </script>
 </body>
 </html>


### PR DESCRIPTION
Fixes #9.

Scaffolds the `docs/` directory with an index.html that loads JsCoq and exposes a game canvas for the future Quake 3 surface. Adds responsive layout for desktop and mobile viewports, visible error handling for load failures, and a local dev server alongside a GitHub Pages deploy workflow.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] Scaffold docs/ with index.html that loads JsCoq and exposes a game canvas <!-- type:spec -->
- [x] Add visible error handling for JsCoq and asset load failures <!-- type:spec -->
- [x] Add local dev server and GitHub Pages deploy workflow <!-- type:spec -->
- [x] [Fix CI failure on this branch](https://github.com/rhencke/orly/pull/32#issuecomment-4248655270) <!-- type:thread -->
</details>
<!-- WORK_QUEUE_END -->