### PR TITLE
Lock the v1 port boundary and Rocq/JS execution split (closes #13)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3,7 +3,9 @@
 This document defines which responsibilities live in Rocq (executed via
 JsCoq in the browser) and which stay in the JavaScript/browser shell.
 Later issues should be judged against these decisions to determine whether
-they are on-architecture or off-architecture.
+they are on-architecture or off-architecture.  The concrete v1 acceptance
+criteria that this boundary governs are in
+[V1_CHECKLIST.md](V1_CHECKLIST.md).
 
 ## Execution path
 

--- a/V1_CHECKLIST.md
+++ b/V1_CHECKLIST.md
@@ -4,7 +4,9 @@ This document defines the exact acceptance target for
 [issue #12](https://github.com/rhencke/orly/issues/12).  Everything on this
 list must be true before v1 ships.  Anything not on this list is either
 explicitly deferred to [issue #18](https://github.com/rhencke/orly/issues/18)
-or out of scope entirely.
+or out of scope entirely.  The Rocq/JS boundary that governs which items
+belong in Rocq versus JavaScript is defined in
+[ARCHITECTURE.md](ARCHITECTURE.md).
 
 ## Chosen level: q3dm1 — Arena Gate
 


### PR DESCRIPTION
Fixes #13.

Cross-references ARCHITECTURE.md and V1_CHECKLIST.md so they form one coherent v1 engineering contract instead of two independent documents. Both docs were delivered by sub-issues #19 and #20 — this PR ties them together and closes the umbrella.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Cross-reference ARCHITECTURE.md and V1_CHECKLIST.md as the v1 contract <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->