### PR TITLE
Package Quake 3 demo assets for browser delivery (closes #14)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -300,12 +300,59 @@ Qed.
       showStatus(`Error: ${msg}`, 'error');
     });
 
+    // ── asset loader ─────────────────────────────────────────────
+    //
+    // Loads game assets produced by `make assets`.  Fetches
+    // assets/manifest.json first to discover what files are available,
+    // then retrieves each as an ArrayBuffer using parallel fetches.
+    //
+    // Returns a Map<string, ArrayBuffer> keyed by relative asset path
+    // (e.g. "maps/q3dm1.bsp").  The renderer (issue #15) reads from
+    // window.orlyAssets at draw time.
+    //
+    // Graceful degradation: a missing manifest (HTTP 404) just means the
+    // assets have not been extracted yet — normal on GitHub Pages (EULA
+    // prohibits hosting extracted files) and in fresh checkouts.  The
+    // function returns an empty Map without surfacing a user-visible error.
+    async function loadAssets() {
+      let manifest;
+      try {
+        const resp = await fetch('assets/manifest.json');
+        if (resp.status === 404) return new Map();
+        if (!resp.ok) throw new Error(`manifest fetch failed: HTTP ${resp.status}`);
+        manifest = await resp.json();
+      } catch (err) {
+        // Network-level failure (offline, file:// origin, CORS) — not fatal.
+        if (err instanceof TypeError) return new Map();
+        throw err;
+      }
+
+      if (!Array.isArray(manifest) || manifest.length === 0) return new Map();
+
+      const total = manifest.length;
+      const assets = new Map();
+      let loaded = 0;
+
+      showStatus(`Loading assets: 0 / ${total}`);
+
+      // Fetch all files in parallel; update the counter as each completes.
+      await Promise.all(manifest.map(async (path) => {
+        const resp = await fetch(`assets/${path}`);
+        if (!resp.ok) throw new Error(`${path}: HTTP ${resp.status}`);
+        assets.set(path, await resp.arrayBuffer());
+        showStatus(`Loading assets: ${++loaded} / ${total}`);
+      }));
+
+      return assets;
+    }
+
     // ── JsCoq bootstrap ─────────────────────────────────────────
     // Loaded from jsDelivr CDN. Uses dynamic import so we can catch
     // network failures and surface them in the status bar instead of
     // silently failing (a static import failure kills the whole module).
     const JSCOQ_CDN = 'https://cdn.jsdelivr.net/npm/jscoq@0.17.1/';
 
+    let jscoqOk = false;
     showStatus('Loading JsCoq…');
     try {
       const { JsCoq } = await import('https://cdn.jsdelivr.net/npm/jscoq@0.17.1/jscoq.js');
@@ -321,10 +368,27 @@ Qed.
           all_pkgs:      ['coq'],
         }
       );
-      clearStatus();
+      jscoqOk = true;
     } catch (err) {
       showStatus(`Failed to load JsCoq: ${err.message}`, 'error');
       console.error('JsCoq bootstrap failed:', err);
+    }
+
+    // ── asset loading ────────────────────────────────────────────
+    // Runs after JsCoq.start() is called; the Rocq kernel boots
+    // asynchronously in the background while we fetch game data.
+    // Only updates the status bar when JsCoq is healthy — a JsCoq
+    // failure leaves its error message visible rather than overwriting
+    // it with asset progress.
+    try {
+      window.orlyAssets = await loadAssets();
+      if (window.orlyAssets.size > 0)
+        console.log(`orly: loaded ${window.orlyAssets.size} game assets`);
+      if (jscoqOk) clearStatus();
+    } catch (err) {
+      console.error('Asset loading failed:', err);
+      window.orlyAssets = new Map();
+      if (jscoqOk) showStatus(`Failed to load assets: ${err.message}`, 'error');
     }
 
     // ── game canvas sizing ───────────────────────────────────────

--- a/extract_assets/main.ml
+++ b/extract_assets/main.ml
@@ -114,6 +114,34 @@ let open_pak0 (path : string) : bytes =
   | _ -> data  (* .pk3 or unrecognised — try directly as ZIP *)
 
 (* ------------------------------------------------------------------ *)
+(* JSON manifest                                                        *)
+(* ------------------------------------------------------------------ *)
+
+(** Write manifest.json to the output directory listing all extracted
+    asset paths as a sorted JSON array.  The browser fetches this first
+    so it knows what files to load without a hardcoded path list. *)
+let write_manifest (output : string) (paths : string list) : unit =
+  let buf = Buffer.create (List.length paths * 40) in
+  Buffer.add_string buf "[\n";
+  let n = List.length paths in
+  List.iteri (fun i s ->
+    Buffer.add_string buf "  \"";
+    String.iter (fun c ->
+      match c with
+      | '"'  -> Buffer.add_string buf "\\\""
+      | '\\' -> Buffer.add_string buf "\\\\"
+      | c    -> Buffer.add_char buf c
+    ) s;
+    Buffer.add_char buf '"';
+    if i < n - 1 then Buffer.add_char buf ',';
+    Buffer.add_char buf '\n'
+  ) paths;
+  Buffer.add_string buf "]\n";
+  let manifest_path = Filename.concat output "manifest.json" in
+  write_file manifest_path (Buffer.contents buf);
+  Printf.printf "Wrote %s (%d entries).\n%!" manifest_path n
+
+(* ------------------------------------------------------------------ *)
 (* Core extraction using Rocq-extracted logic                          *)
 (* ------------------------------------------------------------------ *)
 
@@ -152,26 +180,19 @@ let rec extract (source : string) (output : string) : unit =
     write_file dest data
   ) to_extract;
 
-  validate output (List.length to_extract)
+  (* Collect extracted filenames (already sorted) for validation and manifest. *)
+  let extracted_paths = List.map (fun (e : Zip_reader.entry) -> e.filename) to_extract in
+  validate output extracted_paths
 
-and validate (output : string) (extracted_count : int) : unit =
-  (* Collect all extracted file paths relative to the output directory,
-     lowercased for the Rocq-extracted validator. *)
-  let rec walk dir prefix acc =
-    let entries = Sys.readdir dir in
-    Array.fold_left (fun acc name ->
-      let full = Filename.concat dir name in
-      let rel = if prefix = "" then name else prefix ^ "/" ^ name in
-      if Sys.is_directory full then walk full rel acc
-      else (String.lowercase_ascii rel) :: acc
-    ) acc entries
-  in
-  let extracted_lc = walk output "" [] in
+and validate (output : string) (paths : string list) : unit =
+  (* Lowercase for the Rocq-extracted validator (case-insensitive matching). *)
+  let extracted_lc = List.map String.lowercase_ascii paths in
   let extracted_cl = List.map charlist_of_string extracted_lc in
 
-  if Extract_assets_core.validate_manifest extracted_cl then
-    Printf.printf "Done — %d files extracted and manifest validated.\n%!" extracted_count
-  else begin
+  if Extract_assets_core.validate_manifest extracted_cl then begin
+    Printf.printf "Done — %d files extracted and manifest validated.\n%!" (List.length paths);
+    write_manifest output paths
+  end else begin
     let missing_f = Extract_assets_core.missing_files extracted_cl in
     let missing_p = Extract_assets_core.missing_prefixes extracted_cl in
     Printf.eprintf "error: the following required assets are missing from pak0.pk3:\n%!";


### PR DESCRIPTION
Fixes #14.

The extract_assets pipeline already unpacks demo assets into `docs/assets/`, but the browser shell has no idea what's there. This PR adds a JSON manifest emitted at extraction time and a JavaScript asset loader that fetches everything listed in it, with progress shown in the status bar — closing the last "done when" gap so the browser can consume assets without hand steps or ad hoc paths.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (10)</summary>

- [x] Gitignore the docs/assets directory for extracted demo files <!-- type:spec -->
- [x] Add Python script to extract and validate q3dm1 assets from pak0.pk3 <!-- type:spec -->
- [x] Add demo installer unpacking to extract pak0.pk3 automatically <!-- type:spec -->
- [x] Add make assets target and document the setup workflow <!-- type:spec -->
- [x] ASK: Clarify approach for removing Python and using only Rocq in README <!-- type:thread -->
- [x] [Rewrite extract_assets.py in Rocq with OCaml extraction](https://github.com/rhencke/orly/pull/39#discussion_r3087327507) <!-- type:thread -->
- [x] Remove Python from README, document Rocq-only approach <!-- type:spec -->
- [x] Pull without pushing or handling failures <!-- type:thread -->
- [x] Emit manifest.json from extract_assets after extraction <!-- type:spec -->
- [x] Add browser asset loader with progress UI to index.html <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->