### PR TITLE
Render the static demo level from the Rocq-powered core (closes #24)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ THEORIES := \
   theories/BspNodeLeaf.v \
   theories/BspTexture.v \
   theories/BspBrush.v \
+  theories/BspFace.v \
   theories/BspLightmapVisEffect.v \
   theories/BspEntity.v \
   theories/BspFile.v \

--- a/_RocqProject
+++ b/_RocqProject
@@ -7,6 +7,7 @@ theories/BspPlaneVertex.v
 theories/BspNodeLeaf.v
 theories/BspTexture.v
 theories/BspBrush.v
+theories/BspFace.v
 theories/BspLightmapVisEffect.v
 theories/BspEntity.v
 theories/BspFile.v

--- a/docs/bsp.js
+++ b/docs/bsp.js
@@ -1,0 +1,435 @@
+// ── Q3 BSP binary reader ──────────────────────────────────────────
+//
+// Mirrors the Rocq-side BSP parser (theories/BspFormat.v, BspFace.v,
+// BspPlaneVertex.v, etc.) but reads directly from an ArrayBuffer for
+// WebGL consumption.  All field names and byte offsets match the Rocq
+// definitions so the two parsers stay in sync.
+//
+// Usage:
+//   import { parseBsp } from './bsp.js';
+//   const bsp = parseBsp(arrayBuffer);  // throws on invalid input
+
+// ── constants ────────────────────────────────────────────────────────
+const BSP_MAGIC   = 0x49425350;  // "IBSP" little-endian
+const BSP_VERSION = 46;
+const NUM_LUMPS   = 17;
+
+// Lump indices — must match BspFormat.v LumpIndex enumeration
+const LUMP_ENTITIES     =  0;
+const LUMP_TEXTURES     =  1;
+const LUMP_PLANES       =  2;
+const LUMP_NODES        =  3;
+const LUMP_LEAVES       =  4;
+const LUMP_LEAF_FACES   =  5;
+const LUMP_LEAF_BRUSHES =  6;
+const LUMP_MODELS       =  7;
+const LUMP_BRUSHES      =  8;
+const LUMP_BRUSH_SIDES  =  9;
+const LUMP_VERTEXES     = 10;
+const LUMP_MESH_VERTS   = 11;
+const LUMP_EFFECTS      = 12;
+const LUMP_FACES        = 13;
+const LUMP_LIGHTMAPS    = 14;
+const LUMP_LIGHT_VOLS   = 15;
+const LUMP_VIS_DATA     = 16;
+
+// Entry sizes in bytes — must match Rocq *_size definitions
+const TEXTURE_SIZE    = 72;
+const PLANE_SIZE      = 16;
+const NODE_SIZE       = 36;
+const LEAF_SIZE       = 48;
+const BRUSH_SIZE      = 12;
+const BRUSH_SIDE_SIZE =  8;
+const VERTEX_SIZE     = 44;
+const FACE_SIZE       = 104;
+const EFFECT_SIZE     = 72;
+const LIGHTMAP_SIZE   = 49152;  // 128 * 128 * 3
+const MODEL_SIZE      = 40;
+
+// ── lump directory ───────────────────────────────────────────────────
+
+function readLumpDirectory(view) {
+  const dir = new Array(NUM_LUMPS);
+  // Directory starts at byte 8 (after magic + version); 8 bytes per entry.
+  for (let i = 0; i < NUM_LUMPS; i++) {
+    const base = 8 + i * 8;
+    dir[i] = {
+      offset: view.getInt32(base, true),
+      length: view.getInt32(base + 4, true),
+    };
+  }
+  return dir;
+}
+
+// ── typed lump readers ───────────────────────────────────────────────
+
+function lumpCount(entry, entrySize) {
+  return entrySize > 0 ? Math.floor(entry.length / entrySize) : 0;
+}
+
+// Textures (lump 1) — matches BspTexture.v bsp_texture
+function readTextures(view, entry) {
+  const count = lumpCount(entry, TEXTURE_SIZE);
+  const textures = new Array(count);
+  for (let i = 0; i < count; i++) {
+    const base = entry.offset + i * TEXTURE_SIZE;
+    // 64-byte null-terminated name string
+    const nameBytes = new Uint8Array(view.buffer, base, 64);
+    const nullIdx = nameBytes.indexOf(0);
+    const name = new TextDecoder('ascii').decode(
+      nameBytes.subarray(0, nullIdx >= 0 ? nullIdx : 64)
+    );
+    textures[i] = {
+      name,
+      flags:    view.getInt32(base + 64, true),
+      contents: view.getInt32(base + 68, true),
+    };
+  }
+  return textures;
+}
+
+// Planes (lump 2) — matches BspPlaneVertex.v bsp_plane
+function readPlanes(view, entry) {
+  const count = lumpCount(entry, PLANE_SIZE);
+  const planes = new Array(count);
+  for (let i = 0; i < count; i++) {
+    const base = entry.offset + i * PLANE_SIZE;
+    planes[i] = {
+      normalX: view.getFloat32(base,      true),
+      normalY: view.getFloat32(base +  4, true),
+      normalZ: view.getFloat32(base +  8, true),
+      dist:    view.getFloat32(base + 12, true),
+    };
+  }
+  return planes;
+}
+
+// Nodes (lump 3) — matches BspNodeLeaf.v bsp_node
+function readNodes(view, entry) {
+  const count = lumpCount(entry, NODE_SIZE);
+  const nodes = new Array(count);
+  for (let i = 0; i < count; i++) {
+    const base = entry.offset + i * NODE_SIZE;
+    nodes[i] = {
+      plane:      view.getInt32(base,      true),
+      childFront: view.getInt32(base +  4, true),
+      childBack:  view.getInt32(base +  8, true),
+      minsX:      view.getInt32(base + 12, true),
+      minsY:      view.getInt32(base + 16, true),
+      minsZ:      view.getInt32(base + 20, true),
+      maxsX:      view.getInt32(base + 24, true),
+      maxsY:      view.getInt32(base + 28, true),
+      maxsZ:      view.getInt32(base + 32, true),
+    };
+  }
+  return nodes;
+}
+
+// Leaves (lump 4) — matches BspNodeLeaf.v bsp_leaf
+function readLeaves(view, entry) {
+  const count = lumpCount(entry, LEAF_SIZE);
+  const leaves = new Array(count);
+  for (let i = 0; i < count; i++) {
+    const base = entry.offset + i * LEAF_SIZE;
+    leaves[i] = {
+      cluster:         view.getInt32(base,      true),
+      area:            view.getInt32(base +  4, true),
+      minsX:           view.getInt32(base +  8, true),
+      minsY:           view.getInt32(base + 12, true),
+      minsZ:           view.getInt32(base + 16, true),
+      maxsX:           view.getInt32(base + 20, true),
+      maxsY:           view.getInt32(base + 24, true),
+      maxsZ:           view.getInt32(base + 28, true),
+      firstLeafFace:   view.getInt32(base + 32, true),
+      numLeafFaces:    view.getInt32(base + 36, true),
+      firstLeafBrush:  view.getInt32(base + 40, true),
+      numLeafBrushes:  view.getInt32(base + 44, true),
+    };
+  }
+  return leaves;
+}
+
+// Leaf-faces (lump 5) and leaf-brushes (lump 6) — i32 index arrays
+function readI32Lump(view, entry) {
+  const count = lumpCount(entry, 4);
+  const arr = new Int32Array(count);
+  for (let i = 0; i < count; i++) {
+    arr[i] = view.getInt32(entry.offset + i * 4, true);
+  }
+  return arr;
+}
+
+// Models (lump 7) — matches BspBrush.v bsp_model
+function readModels(view, entry) {
+  const count = lumpCount(entry, MODEL_SIZE);
+  const models = new Array(count);
+  for (let i = 0; i < count; i++) {
+    const base = entry.offset + i * MODEL_SIZE;
+    models[i] = {
+      minsX:     view.getFloat32(base,      true),
+      minsY:     view.getFloat32(base +  4, true),
+      minsZ:     view.getFloat32(base +  8, true),
+      maxsX:     view.getFloat32(base + 12, true),
+      maxsY:     view.getFloat32(base + 16, true),
+      maxsZ:     view.getFloat32(base + 20, true),
+      firstFace: view.getInt32(base + 24, true),
+      numFaces:  view.getInt32(base + 28, true),
+      firstBrush: view.getInt32(base + 32, true),
+      numBrushes: view.getInt32(base + 36, true),
+    };
+  }
+  return models;
+}
+
+// Brushes (lump 8) — matches BspBrush.v bsp_brush
+function readBrushes(view, entry) {
+  const count = lumpCount(entry, BRUSH_SIZE);
+  const brushes = new Array(count);
+  for (let i = 0; i < count; i++) {
+    const base = entry.offset + i * BRUSH_SIZE;
+    brushes[i] = {
+      firstSide:    view.getInt32(base,     true),
+      numSides:     view.getInt32(base + 4, true),
+      textureIndex: view.getInt32(base + 8, true),
+    };
+  }
+  return brushes;
+}
+
+// Brush sides (lump 9) — matches BspBrush.v bsp_brush_side
+function readBrushSides(view, entry) {
+  const count = lumpCount(entry, BRUSH_SIDE_SIZE);
+  const sides = new Array(count);
+  for (let i = 0; i < count; i++) {
+    const base = entry.offset + i * BRUSH_SIDE_SIZE;
+    sides[i] = {
+      planeIndex:   view.getInt32(base,     true),
+      textureIndex: view.getInt32(base + 4, true),
+    };
+  }
+  return sides;
+}
+
+// Vertices (lump 10) — matches BspPlaneVertex.v bsp_vertex
+function readVertices(view, entry) {
+  const count = lumpCount(entry, VERTEX_SIZE);
+  const vertices = new Array(count);
+  for (let i = 0; i < count; i++) {
+    const base = entry.offset + i * VERTEX_SIZE;
+    vertices[i] = {
+      posX:    view.getFloat32(base,      true),
+      posY:    view.getFloat32(base +  4, true),
+      posZ:    view.getFloat32(base +  8, true),
+      texS:    view.getFloat32(base + 12, true),
+      texT:    view.getFloat32(base + 16, true),
+      lmS:     view.getFloat32(base + 20, true),
+      lmT:     view.getFloat32(base + 24, true),
+      normalX: view.getFloat32(base + 28, true),
+      normalY: view.getFloat32(base + 32, true),
+      normalZ: view.getFloat32(base + 36, true),
+      colorR:  view.getUint8(base + 40),
+      colorG:  view.getUint8(base + 41),
+      colorB:  view.getUint8(base + 42),
+      colorA:  view.getUint8(base + 43),
+    };
+  }
+  return vertices;
+}
+
+// Mesh verts (lump 11) — i32 offset indices
+// (reuses readI32Lump)
+
+// Effects (lump 12) — matches BspLightmapVisEffect.v bsp_effect
+function readEffects(view, entry) {
+  const count = lumpCount(entry, EFFECT_SIZE);
+  const effects = new Array(count);
+  for (let i = 0; i < count; i++) {
+    const base = entry.offset + i * EFFECT_SIZE;
+    const nameBytes = new Uint8Array(view.buffer, base, 64);
+    const nullIdx = nameBytes.indexOf(0);
+    const name = new TextDecoder('ascii').decode(
+      nameBytes.subarray(0, nullIdx >= 0 ? nullIdx : 64)
+    );
+    effects[i] = {
+      name,
+      brushIndex: view.getInt32(base + 64, true),
+      unknown:    view.getInt32(base + 68, true),
+    };
+  }
+  return effects;
+}
+
+// Faces (lump 13) — matches BspFace.v bsp_face
+function readFaces(view, entry) {
+  const count = lumpCount(entry, FACE_SIZE);
+  const faces = new Array(count);
+  for (let i = 0; i < count; i++) {
+    const base = entry.offset + i * FACE_SIZE;
+    faces[i] = {
+      texture:     view.getInt32(base,       true),
+      effect:      view.getInt32(base +   4, true),
+      type:        view.getInt32(base +   8, true),
+      vertex:      view.getInt32(base +  12, true),
+      nVertexes:   view.getInt32(base +  16, true),
+      meshvert:    view.getInt32(base +  20, true),
+      nMeshverts:  view.getInt32(base +  24, true),
+      lmIndex:     view.getInt32(base +  28, true),
+      lmStartX:    view.getInt32(base +  32, true),
+      lmStartY:    view.getInt32(base +  36, true),
+      lmSizeX:     view.getInt32(base +  40, true),
+      lmSizeY:     view.getInt32(base +  44, true),
+      lmOriginX:   view.getFloat32(base + 48, true),
+      lmOriginY:   view.getFloat32(base + 52, true),
+      lmOriginZ:   view.getFloat32(base + 56, true),
+      lmVecsSX:    view.getFloat32(base + 60, true),
+      lmVecsSY:    view.getFloat32(base + 64, true),
+      lmVecsSZ:    view.getFloat32(base + 68, true),
+      lmVecsTX:    view.getFloat32(base + 72, true),
+      lmVecsTY:    view.getFloat32(base + 76, true),
+      lmVecsTZ:    view.getFloat32(base + 80, true),
+      normalX:     view.getFloat32(base + 84, true),
+      normalY:     view.getFloat32(base + 88, true),
+      normalZ:     view.getFloat32(base + 92, true),
+      sizeX:       view.getInt32(base +  96, true),
+      sizeY:       view.getInt32(base + 100, true),
+    };
+  }
+  return faces;
+}
+
+// Lightmaps (lump 14) — matches BspLightmapVisEffect.v bsp_lightmap
+// Each lightmap is 128x128 RGB (49152 bytes).
+function readLightmaps(view, entry) {
+  const count = lumpCount(entry, LIGHTMAP_SIZE);
+  const lightmaps = new Array(count);
+  for (let i = 0; i < count; i++) {
+    const base = entry.offset + i * LIGHTMAP_SIZE;
+    lightmaps[i] = new Uint8Array(view.buffer, base, LIGHTMAP_SIZE);
+  }
+  return lightmaps;
+}
+
+// Vis data (lump 16) — matches BspLightmapVisEffect.v bsp_vis_data
+function readVisData(view, entry) {
+  if (entry.length < 8) return null;
+  const numClusters = view.getInt32(entry.offset, true);
+  const bytesPerCluster = view.getInt32(entry.offset + 4, true);
+  const vecs = new Uint8Array(view.buffer, entry.offset + 8, entry.length - 8);
+  return { numClusters, bytesPerCluster, vecs };
+}
+
+// Entities (lump 0) — matches BspEntity.v (raw text, parsed separately)
+function readEntities(view, entry) {
+  if (entry.length === 0) return '';
+  const bytes = new Uint8Array(view.buffer, entry.offset, entry.length);
+  // Strip trailing null byte(s)
+  let end = bytes.length;
+  while (end > 0 && bytes[end - 1] === 0) end--;
+  return new TextDecoder('ascii').decode(bytes.subarray(0, end));
+}
+
+// ── entity string parser ─────────────────────────────────────────────
+//
+// Q3 entity strings are a sequence of { key "value" ... } blocks.
+// Returns an array of Map<string, string> objects.
+
+function parseEntities(entityString) {
+  const entities = [];
+  let current = null;
+  // Tokenize: braces and quoted strings
+  const re = /[{}]|"([^"]*)"/g;
+  let m;
+  const tokens = [];
+  while ((m = re.exec(entityString)) !== null) {
+    if (m[0] === '{' || m[0] === '}') {
+      tokens.push({ type: m[0] });
+    } else {
+      tokens.push({ type: 'string', value: m[1] });
+    }
+  }
+  let i = 0;
+  while (i < tokens.length) {
+    const tok = tokens[i];
+    if (tok.type === '{') {
+      current = new Map();
+      i++;
+    } else if (tok.type === '}') {
+      if (current) entities.push(current);
+      current = null;
+      i++;
+    } else if (tok.type === 'string' && current) {
+      const key = tok.value;
+      i++;
+      if (i < tokens.length && tokens[i].type === 'string') {
+        current.set(key, tokens[i].value);
+        i++;
+      }
+    } else {
+      i++;
+    }
+  }
+  return entities;
+}
+
+// ── face type constants ──────────────────────────────────────────────
+// Matches BspFace.v fc_type field values.
+export const FACE_POLYGON  = 1;
+export const FACE_PATCH    = 2;
+export const FACE_MESH     = 3;
+export const FACE_BILLBOARD = 4;
+
+// ── top-level parser ─────────────────────────────────────────────────
+
+/**
+ * Parse a Q3 BSP file from an ArrayBuffer.
+ *
+ * Returns a structured object mirroring the Rocq-side bsp_file record
+ * (theories/BspFile.v).  Throws on invalid magic or version.
+ *
+ * @param {ArrayBuffer} buffer
+ * @returns {object} Parsed BSP data
+ */
+export function parseBsp(buffer) {
+  if (buffer.byteLength < 8 + NUM_LUMPS * 8) {
+    throw new Error(`BSP too short: ${buffer.byteLength} bytes (need at least ${8 + NUM_LUMPS * 8})`);
+  }
+
+  const view = new DataView(buffer);
+
+  // Validate header — matches BspFormat.v parse_bsp_header
+  const magic   = view.getUint32(0, true);
+  const version = view.getInt32(4, true);
+  if (magic !== BSP_MAGIC) {
+    throw new Error(`Bad BSP magic: 0x${magic.toString(16)} (expected 0x${BSP_MAGIC.toString(16)})`);
+  }
+  if (version !== BSP_VERSION) {
+    throw new Error(`Bad BSP version: ${version} (expected ${BSP_VERSION})`);
+  }
+
+  const dir = readLumpDirectory(view);
+
+  const entityString = readEntities(view, dir[LUMP_ENTITIES]);
+
+  return {
+    magic,
+    version,
+    directory: dir,
+    entities:    parseEntities(entityString),
+    entityString,
+    textures:    readTextures(view, dir[LUMP_TEXTURES]),
+    planes:      readPlanes(view, dir[LUMP_PLANES]),
+    nodes:       readNodes(view, dir[LUMP_NODES]),
+    leaves:      readLeaves(view, dir[LUMP_LEAVES]),
+    leafFaces:   readI32Lump(view, dir[LUMP_LEAF_FACES]),
+    leafBrushes: readI32Lump(view, dir[LUMP_LEAF_BRUSHES]),
+    models:      readModels(view, dir[LUMP_MODELS]),
+    brushes:     readBrushes(view, dir[LUMP_BRUSHES]),
+    brushSides:  readBrushSides(view, dir[LUMP_BRUSH_SIDES]),
+    vertices:    readVertices(view, dir[LUMP_VERTEXES]),
+    meshVerts:   readI32Lump(view, dir[LUMP_MESH_VERTS]),
+    effects:     readEffects(view, dir[LUMP_EFFECTS]),
+    faces:       readFaces(view, dir[LUMP_FACES]),
+    lightmaps:   readLightmaps(view, dir[LUMP_LIGHTMAPS]),
+    visData:     readVisData(view, dir[LUMP_VIS_DATA]),
+  };
+}

--- a/docs/camera.js
+++ b/docs/camera.js
@@ -1,0 +1,173 @@
+// ── Keyboard + mouse fly camera for Q3 BSP level inspection ─────
+//
+// Noclip-style free camera in Q3's Z-up right-handed coordinate
+// system.  Click the canvas to engage pointer lock; WASD to fly,
+// mouse to look, Space/Shift for vertical movement.
+//
+// Usage:
+//   import { createFlyCamera } from './camera.js';
+//   const cam = createFlyCamera(canvas, { x, y, z, yaw, pitch });
+//   // in render loop:
+//   cam.update(dt);
+//   renderer.render(cam.viewMatrix, projMatrix);
+//   // cleanup:
+//   cam.destroy();
+
+import { mat4LookAt } from './renderer.js';
+
+const DEG_TO_RAD = Math.PI / 180;
+
+// ── default config ───────────────────────────────────────────────────
+
+const DEFAULT_SPEED     = 320;   // units/sec (Q3 run speed)
+const DEFAULT_FAST_MULT = 3;     // shift multiplier
+const MOUSE_SENSITIVITY = 0.15;  // degrees per pixel of mouse movement
+const PITCH_LIMIT       = 89;    // ±degrees — prevent gimbal flip
+
+// ── key bindings ─────────────────────────────────────────────────────
+
+const KEY_FORWARD  = new Set(['KeyW', 'ArrowUp']);
+const KEY_BACK     = new Set(['KeyS', 'ArrowDown']);
+const KEY_LEFT     = new Set(['KeyA', 'ArrowLeft']);
+const KEY_RIGHT    = new Set(['KeyD', 'ArrowRight']);
+const KEY_UP       = new Set(['Space']);
+const KEY_DOWN     = new Set(['ShiftLeft', 'ShiftRight']);
+const KEY_FAST     = new Set(['ShiftLeft', 'ShiftRight']);
+
+/**
+ * Create a fly camera attached to a canvas element.
+ *
+ * @param {HTMLCanvasElement} canvas — click to engage pointer lock
+ * @param {{ x?: number, y?: number, z?: number, yaw?: number, pitch?: number }} init
+ * @returns {{ viewMatrix: Float32Array, update(dt: number): void, destroy(): void }}
+ */
+export function createFlyCamera(canvas, init = {}) {
+  // ── state ────────────────────────────────────────────────────────
+  let posX  = init.x     ?? 0;
+  let posY  = init.y     ?? 0;
+  let posZ  = init.z     ?? 0;
+  let yaw   = init.yaw   ?? 0;   // degrees, 0 = +X, 90 = +Y (Q3 convention)
+  let pitch = init.pitch ?? 0;   // degrees, positive = look up
+
+  const viewMatrix = new Float32Array(16);
+  const pressed = new Set();      // currently held key codes
+  let mouseDX = 0, mouseDY = 0;  // accumulated mouse delta since last update
+
+  // ── pointer lock ─────────────────────────────────────────────────
+  function requestLock() {
+    canvas.requestPointerLock?.();
+  }
+
+  function onMouseMove(e) {
+    if (document.pointerLockElement !== canvas) return;
+    mouseDX += e.movementX;
+    mouseDY += e.movementY;
+  }
+
+  // ── keyboard ─────────────────────────────────────────────────────
+  function onKeyDown(e) {
+    // Don't capture keys when typing in JsCoq or other inputs
+    if (e.target.tagName === 'TEXTAREA' || e.target.tagName === 'INPUT') return;
+    if (e.target.isContentEditable) return;
+    pressed.add(e.code);
+    // Prevent default for game keys to avoid page scroll
+    if (KEY_FORWARD.has(e.code) || KEY_BACK.has(e.code) ||
+        KEY_LEFT.has(e.code) || KEY_RIGHT.has(e.code) ||
+        KEY_UP.has(e.code)) {
+      e.preventDefault();
+    }
+  }
+
+  function onKeyUp(e) {
+    pressed.delete(e.code);
+  }
+
+  // Clear pressed keys when pointer lock is lost so we don't get
+  // stuck-key ghosts (keyup fires on the document, not the canvas,
+  // but browser behavior varies on lock exit).
+  function onLockChange() {
+    if (document.pointerLockElement !== canvas) {
+      pressed.clear();
+    }
+  }
+
+  // ── bind events ──────────────────────────────────────────────────
+  canvas.addEventListener('click', requestLock);
+  document.addEventListener('mousemove', onMouseMove);
+  document.addEventListener('keydown', onKeyDown);
+  document.addEventListener('keyup', onKeyUp);
+  document.addEventListener('pointerlockchange', onLockChange);
+
+  // ── helpers ──────────────────────────────────────────────────────
+  function isPressed(keySet) {
+    for (const k of keySet) if (pressed.has(k)) return true;
+    return false;
+  }
+
+  // ── per-frame update ─────────────────────────────────────────────
+  function update(dt) {
+    // Apply mouse look
+    if (mouseDX !== 0 || mouseDY !== 0) {
+      yaw   -= mouseDX * MOUSE_SENSITIVITY;
+      pitch -= mouseDY * MOUSE_SENSITIVITY;
+      // Normalize yaw to [0, 360)
+      yaw = ((yaw % 360) + 360) % 360;
+      // Clamp pitch
+      pitch = Math.max(-PITCH_LIMIT, Math.min(PITCH_LIMIT, pitch));
+      mouseDX = 0;
+      mouseDY = 0;
+    }
+
+    // Movement — relative to current yaw (pitch does not affect move direction,
+    // only the look direction; this feels natural for noclip inspection)
+    const speed = isPressed(KEY_FAST)
+      ? DEFAULT_SPEED * DEFAULT_FAST_MULT
+      : DEFAULT_SPEED;
+    const dist = speed * dt;
+
+    const yawRad = yaw * DEG_TO_RAD;
+    const cosYaw = Math.cos(yawRad);
+    const sinYaw = Math.sin(yawRad);
+
+    // Forward/back along the yaw direction (XY plane)
+    if (isPressed(KEY_FORWARD)) { posX += cosYaw * dist; posY += sinYaw * dist; }
+    if (isPressed(KEY_BACK))    { posX -= cosYaw * dist; posY -= sinYaw * dist; }
+
+    // Strafe left/right (perpendicular to yaw in XY plane)
+    if (isPressed(KEY_LEFT))  { posX += sinYaw * dist; posY -= cosYaw * dist; }
+    if (isPressed(KEY_RIGHT)) { posX -= sinYaw * dist; posY += cosYaw * dist; }
+
+    // Vertical movement (Z axis, always world-aligned)
+    if (isPressed(KEY_UP))   posZ += dist;
+    if (isPressed(KEY_DOWN)) posZ -= dist;
+
+    // Build view matrix
+    const pitchRad = pitch * DEG_TO_RAD;
+    const cosPitch = Math.cos(pitchRad);
+    const lookX = posX + cosYaw * cosPitch;
+    const lookY = posY + sinYaw * cosPitch;
+    const lookZ = posZ + Math.sin(pitchRad);
+
+    mat4LookAt(viewMatrix,
+               [posX, posY, posZ],
+               [lookX, lookY, lookZ],
+               [0, 0, 1]);
+  }
+
+  // Build initial view matrix
+  update(0);
+
+  // ── cleanup ──────────────────────────────────────────────────────
+  function destroy() {
+    canvas.removeEventListener('click', requestLock);
+    document.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('keydown', onKeyDown);
+    document.removeEventListener('keyup', onKeyUp);
+    document.removeEventListener('pointerlockchange', onLockChange);
+    if (document.pointerLockElement === canvas) {
+      document.exitPointerLock?.();
+    }
+  }
+
+  return { viewMatrix, update, destroy };
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -274,6 +274,9 @@ Qed.
   </div>
 
   <script type="module">
+    import { parseBsp } from './bsp.js';
+    import { createRenderer, mat4Perspective, mat4LookAt } from './renderer.js';
+
     // ── status bar helpers ───────────────────────────────────────
     const statusBar = document.getElementById('status-bar');
 
@@ -389,6 +392,74 @@ Qed.
       console.error('Asset loading failed:', err);
       window.orlyAssets = new Map();
       if (jscoqOk) showStatus(`Failed to load assets: ${err.message}`, 'error');
+    }
+
+    // ── BSP parse + render pipeline ──────────────────────────────
+    // If the BSP file was loaded, parse it and start the renderer.
+    // The placeholder is hidden once WebGL is up and drawing.
+    const bspBuffer = window.orlyAssets.get('maps/q3dm1.bsp');
+    if (bspBuffer) {
+      try {
+        showStatus('Parsing BSP…');
+        const bsp = parseBsp(bspBuffer);
+        console.log(`orly: parsed BSP — ${bsp.faces.length} faces, ` +
+                    `${bsp.vertices.length} vertices, ` +
+                    `${bsp.lightmaps.length} lightmaps`);
+
+        // Find a spawn point from BSP entities for initial camera
+        const spawn = bsp.entities.find(e =>
+          e.get('classname') === 'info_player_deathmatch');
+        let eyeX = 0, eyeY = 0, eyeZ = 0, yawDeg = 0;
+        if (spawn) {
+          const origin = spawn.get('origin');
+          if (origin) {
+            const parts = origin.split(/\s+/).map(Number);
+            eyeX = parts[0] || 0;
+            eyeY = parts[1] || 0;
+            eyeZ = parts[2] || 0;
+            // Q3 stores eye height ~56 units above spawn origin
+            eyeZ += 56;
+          }
+          const angle = spawn.get('angle');
+          if (angle) yawDeg = Number(angle) || 0;
+        }
+
+        showStatus('Initializing renderer…');
+        const renderer = createRenderer(canvas, bsp);
+
+        // Hide the placeholder — WebGL is live
+        document.getElementById('game-placeholder').hidden = true;
+
+        // Pre-allocate matrices for the render loop
+        const viewMatrix = new Float32Array(16);
+        const projMatrix = new Float32Array(16);
+
+        // Convert yaw to a look-at target (Q3: 0° = +x, 90° = +y)
+        const yawRad = yawDeg * Math.PI / 180;
+        const lookX = eyeX + Math.cos(yawRad);
+        const lookY = eyeY + Math.sin(yawRad);
+        const lookZ = eyeZ;
+
+        mat4LookAt(viewMatrix,
+                   [eyeX, eyeY, eyeZ],
+                   [lookX, lookY, lookZ],
+                   [0, 0, 1]);
+
+        function frame() {
+          // Update projection each frame to track canvas resize
+          const aspect = canvas.width / canvas.height || 1;
+          mat4Perspective(projMatrix, Math.PI / 2, aspect, 1.0, 4096.0);
+          renderer.render(viewMatrix, projMatrix);
+          requestAnimationFrame(frame);
+        }
+        requestAnimationFrame(frame);
+
+        clearStatus();
+        console.log('orly: render pipeline active');
+      } catch (err) {
+        console.error('BSP render init failed:', err);
+        showStatus(`Render error: ${err.message}`, 'error');
+      }
     }
 
     // ── game canvas sizing ───────────────────────────────────────

--- a/docs/index.html
+++ b/docs/index.html
@@ -275,7 +275,8 @@ Qed.
 
   <script type="module">
     import { parseBsp } from './bsp.js';
-    import { createRenderer, mat4Perspective, mat4LookAt } from './renderer.js';
+    import { createRenderer, mat4Perspective } from './renderer.js';
+    import { createFlyCamera } from './camera.js';
 
     // ── status bar helpers ───────────────────────────────────────
     const statusBar = document.getElementById('status-bar');
@@ -394,6 +395,11 @@ Qed.
       if (jscoqOk) showStatus(`Failed to load assets: ${err.message}`, 'error');
     }
 
+    // ── game canvas sizing ───────────────────────────────────────
+    // Keep the canvas pixel dimensions in sync with its CSS layout size
+    // so the renderer gets a correctly sized drawing surface.
+    const canvas = document.getElementById('game-canvas');
+
     // ── BSP parse + render pipeline ──────────────────────────────
     // If the BSP file was loaded, parse it and start the renderer.
     // The placeholder is hidden once WebGL is up and drawing.
@@ -427,45 +433,39 @@ Qed.
         showStatus('Initializing renderer…');
         const renderer = createRenderer(canvas, bsp);
 
+        // Create fly camera at the spawn point
+        // Click canvas to engage pointer lock; WASD to move, mouse to look
+        const cam = createFlyCamera(canvas, {
+          x: eyeX, y: eyeY, z: eyeZ, yaw: yawDeg,
+        });
+
         // Hide the placeholder — WebGL is live
         document.getElementById('game-placeholder').hidden = true;
 
-        // Pre-allocate matrices for the render loop
-        const viewMatrix = new Float32Array(16);
         const projMatrix = new Float32Array(16);
+        let lastTime = 0;
 
-        // Convert yaw to a look-at target (Q3: 0° = +x, 90° = +y)
-        const yawRad = yawDeg * Math.PI / 180;
-        const lookX = eyeX + Math.cos(yawRad);
-        const lookY = eyeY + Math.sin(yawRad);
-        const lookZ = eyeZ;
+        function frame(now) {
+          const dt = lastTime ? (now - lastTime) / 1000 : 0;
+          lastTime = now;
 
-        mat4LookAt(viewMatrix,
-                   [eyeX, eyeY, eyeZ],
-                   [lookX, lookY, lookZ],
-                   [0, 0, 1]);
+          cam.update(dt);
 
-        function frame() {
           // Update projection each frame to track canvas resize
           const aspect = canvas.width / canvas.height || 1;
           mat4Perspective(projMatrix, Math.PI / 2, aspect, 1.0, 4096.0);
-          renderer.render(viewMatrix, projMatrix);
+          renderer.render(cam.viewMatrix, projMatrix);
           requestAnimationFrame(frame);
         }
         requestAnimationFrame(frame);
 
         clearStatus();
-        console.log('orly: render pipeline active');
+        console.log('orly: render pipeline active — click canvas to fly');
       } catch (err) {
         console.error('BSP render init failed:', err);
         showStatus(`Render error: ${err.message}`, 'error');
       }
     }
-
-    // ── game canvas sizing ───────────────────────────────────────
-    // Keep the canvas pixel dimensions in sync with its CSS layout size
-    // so future renderers get a correctly sized drawing surface.
-    const canvas = document.getElementById('game-canvas');
     const ro = new ResizeObserver(([entry]) => {
       const { width, height } = entry.contentRect;
       canvas.width  = Math.round(width);

--- a/docs/renderer.js
+++ b/docs/renderer.js
@@ -1,0 +1,408 @@
+// ── WebGL renderer for Q3 BSP face geometry with lightmaps ───────
+//
+// Consumes the parsed BSP data from bsp.js and draws polygon (type 1)
+// and mesh (type 3) faces with lightmap-modulated vertex colors.
+//
+// Usage:
+//   import { createRenderer } from './renderer.js';
+//   const renderer = createRenderer(canvas, bsp);
+//   renderer.render(viewMatrix, projMatrix);
+//   renderer.destroy();
+//
+// Coordinate system: Q3 is right-handed Z-up. We pass vertices
+// through unmodified — the view matrix handles the conversion.
+
+import { FACE_POLYGON, FACE_MESH } from './bsp.js';
+
+// ── shader sources ───────────────────────────────────────────────────
+
+const VERT_SRC = `
+  attribute vec3 a_position;
+  attribute vec2 a_lmCoord;
+  attribute vec2 a_texCoord;
+  attribute vec4 a_color;
+
+  uniform mat4 u_view;
+  uniform mat4 u_proj;
+
+  varying vec2 v_lmCoord;
+  varying vec4 v_color;
+
+  void main() {
+    v_lmCoord = a_lmCoord;
+    v_color   = a_color;
+    gl_Position = u_proj * u_view * vec4(a_position, 1.0);
+  }
+`;
+
+const FRAG_SRC = `
+  precision mediump float;
+
+  uniform sampler2D u_lightmap;
+
+  varying vec2 v_lmCoord;
+  varying vec4 v_color;
+
+  void main() {
+    vec3 lm = texture2D(u_lightmap, v_lmCoord).rgb;
+    // Lightmap modulates vertex color; gamma-correct the lightmap
+    // from sRGB storage to linear, apply, then back to sRGB would be
+    // ideal — but Q3 shipped without gamma correction, so we match
+    // that look for now.  Brighten slightly (×2) because Q3 lightmaps
+    // are authored for the engine's built-in over-brightening.
+    vec3 color = v_color.rgb * lm * 2.0;
+    gl_FragColor = vec4(color, v_color.a);
+  }
+`;
+
+// ── GL helpers ───────────────────────────────────────────────────────
+
+function compileShader(gl, type, src) {
+  const s = gl.createShader(type);
+  gl.shaderSource(s, src);
+  gl.compileShader(s);
+  if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) {
+    const log = gl.getShaderInfoLog(s);
+    gl.deleteShader(s);
+    throw new Error(`Shader compile failed: ${log}`);
+  }
+  return s;
+}
+
+function linkProgram(gl, vs, fs) {
+  const p = gl.createProgram();
+  gl.attachShader(p, vs);
+  gl.attachShader(p, fs);
+  gl.linkProgram(p);
+  if (!gl.getProgramParameter(p, gl.LINK_STATUS)) {
+    const log = gl.getProgramInfoLog(p);
+    gl.deleteProgram(p);
+    throw new Error(`Program link failed: ${log}`);
+  }
+  return p;
+}
+
+// ── surface filtering ────────────────────────────────────────────────
+//
+// Q3 content/surface flags that indicate non-renderable geometry.
+
+const CONTENTS_PLAYERCLIP  = 0x10000;
+const CONTENTS_MONSTERCLIP = 0x20000;
+const SURF_NODRAW = 0x80;
+const SURF_SKY    = 0x4;
+
+function shouldDrawFace(face, textures) {
+  if (face.type !== FACE_POLYGON && face.type !== FACE_MESH) return false;
+  if (face.nMeshverts === 0) return false;
+  const tex = textures[face.texture];
+  if (!tex) return false;
+  if (tex.name === '' || tex.name === 'noshader') return false;
+  if (tex.flags & (SURF_NODRAW | SURF_SKY)) return false;
+  if (tex.contents & (CONTENTS_PLAYERCLIP | CONTENTS_MONSTERCLIP)) return false;
+  return true;
+}
+
+// ── vertex buffer packing ────────────────────────────────────────────
+//
+// Interleaved layout per vertex (32 bytes):
+//   float32 posX, posY, posZ    (bytes  0–11)
+//   float32 lmS, lmT            (bytes 12–19)
+//   float32 texS, texT          (bytes 20–27, for future diffuse textures)
+//   uint8   colorR, G, B, A     (bytes 28–31)
+
+const VERTEX_STRIDE = 32;
+
+function buildVertexBuffer(gl, bsp) {
+  const n = bsp.vertices.length;
+  const buf = new ArrayBuffer(n * VERTEX_STRIDE);
+  const f32 = new Float32Array(buf);
+  const u8  = new Uint8Array(buf);
+
+  for (let i = 0; i < n; i++) {
+    const v = bsp.vertices[i];
+    const fOff = i * 8; // 32 / 4 = 8 floats per vertex
+    f32[fOff + 0] = v.posX;
+    f32[fOff + 1] = v.posY;
+    f32[fOff + 2] = v.posZ;
+    f32[fOff + 3] = v.lmS;
+    f32[fOff + 4] = v.lmT;
+    f32[fOff + 5] = v.texS;
+    f32[fOff + 6] = v.texT;
+    const bOff = i * VERTEX_STRIDE + 28;
+    u8[bOff + 0] = v.colorR;
+    u8[bOff + 1] = v.colorG;
+    u8[bOff + 2] = v.colorB;
+    u8[bOff + 3] = v.colorA;
+  }
+
+  const vbo = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+  gl.bufferData(gl.ARRAY_BUFFER, buf, gl.STATIC_DRAW);
+  return vbo;
+}
+
+// ── index buffer + draw groups ───────────────────────────────────────
+//
+// Group faces by lightmap index so we can batch draw calls.
+// Returns { ibo, groups: [{ lmIndex, start, count }], indexType, indexSize }.
+
+function buildIndexBuffer(gl, bsp) {
+  const { faces, meshVerts, textures } = bsp;
+
+  // First pass: count total indices and group by lightmap
+  const groupMap = new Map(); // lmIndex -> [indices...]
+  for (let fi = 0; fi < faces.length; fi++) {
+    const face = faces[fi];
+    if (!shouldDrawFace(face, textures)) continue;
+
+    const lmIdx = face.lmIndex;
+    if (!groupMap.has(lmIdx)) groupMap.set(lmIdx, []);
+    const arr = groupMap.get(lmIdx);
+
+    for (let j = 0; j < face.nMeshverts; j++) {
+      arr.push(face.vertex + meshVerts[face.meshvert + j]);
+    }
+  }
+
+  // Flatten groups into a single index array, recording start/count
+  let totalIndices = 0;
+  for (const arr of groupMap.values()) totalIndices += arr.length;
+
+  // Choose index type based on vertex count
+  const needU32 = bsp.vertices.length > 65535;
+  if (needU32) {
+    const ext = gl.getExtension('OES_element_index_uint');
+    if (!ext) throw new Error('OES_element_index_uint not supported');
+  }
+
+  const indexType = needU32 ? gl.UNSIGNED_INT : gl.UNSIGNED_SHORT;
+  const indexSize = needU32 ? 4 : 2;
+  const indexData = needU32
+    ? new Uint32Array(totalIndices)
+    : new Uint16Array(totalIndices);
+
+  const groups = [];
+  let offset = 0;
+  for (const [lmIdx, arr] of groupMap) {
+    groups.push({ lmIndex: lmIdx, start: offset, count: arr.length });
+    for (let i = 0; i < arr.length; i++) {
+      indexData[offset + i] = arr[i];
+    }
+    offset += arr.length;
+  }
+
+  const ibo = gl.createBuffer();
+  gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+  gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indexData, gl.STATIC_DRAW);
+
+  return { ibo, groups, indexType, indexSize };
+}
+
+// ── lightmap textures ────────────────────────────────────────────────
+
+function uploadLightmaps(gl, bsp) {
+  const textures = [];
+
+  for (let i = 0; i < bsp.lightmaps.length; i++) {
+    const rgb = bsp.lightmaps[i];
+    // WebGL texImage2D with RGB can have alignment issues on some
+    // implementations; expand to RGBA for safety.
+    const rgba = new Uint8Array(128 * 128 * 4);
+    for (let p = 0; p < 128 * 128; p++) {
+      rgba[p * 4 + 0] = rgb[p * 3 + 0];
+      rgba[p * 4 + 1] = rgb[p * 3 + 1];
+      rgba[p * 4 + 2] = rgb[p * 3 + 2];
+      rgba[p * 4 + 3] = 255;
+    }
+
+    const tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 128, 128, 0,
+                  gl.RGBA, gl.UNSIGNED_BYTE, rgba);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    textures.push(tex);
+  }
+
+  // Fallback white 1x1 texture for faces without a lightmap (lmIndex === -1)
+  const white = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, white);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0,
+                gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array([255, 255, 255, 255]));
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+
+  return { textures, white };
+}
+
+// ── minimal mat4 utilities ───────────────────────────────────────────
+//
+// Just enough to set up a default projection and identity view.
+// The camera module (coming later) will provide its own lookAt.
+
+/** Write a 4x4 identity matrix into `out`. */
+export function mat4Identity(out) {
+  out.fill(0);
+  out[0] = out[5] = out[10] = out[15] = 1;
+  return out;
+}
+
+/** Symmetric perspective projection (column-major). */
+export function mat4Perspective(out, fovY, aspect, near, far) {
+  const f = 1.0 / Math.tan(fovY / 2);
+  const nf = 1.0 / (near - far);
+  out[0]  = f / aspect;
+  out[1]  = 0;
+  out[2]  = 0;
+  out[3]  = 0;
+  out[4]  = 0;
+  out[5]  = f;
+  out[6]  = 0;
+  out[7]  = 0;
+  out[8]  = 0;
+  out[9]  = 0;
+  out[10] = (far + near) * nf;
+  out[11] = -1;
+  out[12] = 0;
+  out[13] = 0;
+  out[14] = 2 * far * near * nf;
+  out[15] = 0;
+  return out;
+}
+
+/**
+ * Build a view matrix from eye, center, and up vectors (column-major).
+ * Works correctly with Q3's Z-up coordinate system when up = [0,0,1].
+ */
+export function mat4LookAt(out, eye, center, up) {
+  let fx = center[0] - eye[0];
+  let fy = center[1] - eye[1];
+  let fz = center[2] - eye[2];
+  let len = Math.hypot(fx, fy, fz);
+  if (len > 0) { fx /= len; fy /= len; fz /= len; }
+
+  // side = forward × up
+  let sx = fy * up[2] - fz * up[1];
+  let sy = fz * up[0] - fx * up[2];
+  let sz = fx * up[1] - fy * up[0];
+  len = Math.hypot(sx, sy, sz);
+  if (len > 0) { sx /= len; sy /= len; sz /= len; }
+
+  // recomputed up = side × forward
+  const ux = sy * fz - sz * fy;
+  const uy = sz * fx - sx * fz;
+  const uz = sx * fy - sy * fx;
+
+  out[0]  = sx;
+  out[1]  = ux;
+  out[2]  = -fx;
+  out[3]  = 0;
+  out[4]  = sy;
+  out[5]  = uy;
+  out[6]  = -fy;
+  out[7]  = 0;
+  out[8]  = sz;
+  out[9]  = uz;
+  out[10] = -fz;
+  out[11] = 0;
+  out[12] = -(sx * eye[0] + sy * eye[1] + sz * eye[2]);
+  out[13] = -(ux * eye[0] + uy * eye[1] + uz * eye[2]);
+  out[14] =  (fx * eye[0] + fy * eye[1] + fz * eye[2]);
+  out[15] = 1;
+  return out;
+}
+
+// ── renderer factory ─────────────────────────────────────────────────
+
+/**
+ * Create a WebGL renderer for Q3 BSP face geometry.
+ *
+ * @param {HTMLCanvasElement} canvas — the target canvas
+ * @param {object} bsp — parsed BSP data from parseBsp()
+ * @returns {{ render(view: Float32Array, proj: Float32Array): void, destroy(): void }}
+ */
+export function createRenderer(canvas, bsp) {
+  const gl = canvas.getContext('webgl', { antialias: false, alpha: false });
+  if (!gl) throw new Error('WebGL not available');
+
+  // ── compile shaders ──────────────────────────────────────────────
+  const vs = compileShader(gl, gl.VERTEX_SHADER, VERT_SRC);
+  const fs = compileShader(gl, gl.FRAGMENT_SHADER, FRAG_SRC);
+  const program = linkProgram(gl, vs, fs);
+  gl.deleteShader(vs);
+  gl.deleteShader(fs);
+
+  // ── attribute / uniform locations ────────────────────────────────
+  const aPosition = gl.getAttribLocation(program, 'a_position');
+  const aLmCoord  = gl.getAttribLocation(program, 'a_lmCoord');
+  const aTexCoord = gl.getAttribLocation(program, 'a_texCoord');
+  const aColor    = gl.getAttribLocation(program, 'a_color');
+  const uView     = gl.getUniformLocation(program, 'u_view');
+  const uProj     = gl.getUniformLocation(program, 'u_proj');
+  const uLightmap = gl.getUniformLocation(program, 'u_lightmap');
+
+  // ── build GPU buffers ────────────────────────────────────────────
+  const vbo = buildVertexBuffer(gl, bsp);
+  const { ibo, groups, indexType, indexSize } = buildIndexBuffer(gl, bsp);
+  const lm = uploadLightmaps(gl, bsp);
+
+  // ── GL state ─────────────────────────────────────────────────────
+  gl.clearColor(0.05, 0.05, 0.05, 1.0);
+  gl.enable(gl.DEPTH_TEST);
+  gl.enable(gl.CULL_FACE);
+  // Q3 BSP meshverts produce clockwise front-facing triangles
+  gl.frontFace(gl.CW);
+
+  // ── render function ──────────────────────────────────────────────
+  function render(viewMatrix, projMatrix) {
+    gl.viewport(0, 0, canvas.width, canvas.height);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+    gl.useProgram(program);
+
+    // Matrices
+    gl.uniformMatrix4fv(uView, false, viewMatrix);
+    gl.uniformMatrix4fv(uProj, false, projMatrix);
+
+    // Bind VBO and set attribute pointers
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.enableVertexAttribArray(aPosition);
+    gl.vertexAttribPointer(aPosition, 3, gl.FLOAT, false, VERTEX_STRIDE, 0);
+    gl.enableVertexAttribArray(aLmCoord);
+    gl.vertexAttribPointer(aLmCoord, 2, gl.FLOAT, false, VERTEX_STRIDE, 12);
+    if (aTexCoord >= 0) {
+      gl.enableVertexAttribArray(aTexCoord);
+      gl.vertexAttribPointer(aTexCoord, 2, gl.FLOAT, false, VERTEX_STRIDE, 20);
+    }
+    gl.enableVertexAttribArray(aColor);
+    gl.vertexAttribPointer(aColor, 4, gl.UNSIGNED_BYTE, true, VERTEX_STRIDE, 28);
+
+    // Lightmap sampler
+    gl.activeTexture(gl.TEXTURE0);
+    gl.uniform1i(uLightmap, 0);
+
+    // Bind IBO
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+
+    // Draw each lightmap group
+    for (const g of groups) {
+      const tex = (g.lmIndex >= 0 && g.lmIndex < lm.textures.length)
+        ? lm.textures[g.lmIndex]
+        : lm.white;
+      gl.bindTexture(gl.TEXTURE_2D, tex);
+      gl.drawElements(gl.TRIANGLES, g.count, indexType, g.start * indexSize);
+    }
+  }
+
+  // ── cleanup ──────────────────────────────────────────────────────
+  function destroy() {
+    gl.deleteProgram(program);
+    gl.deleteBuffer(vbo);
+    gl.deleteBuffer(ibo);
+    for (const t of lm.textures) gl.deleteTexture(t);
+    gl.deleteTexture(lm.white);
+  }
+
+  return { render, destroy, gl };
+}

--- a/theories/BspFace.v
+++ b/theories/BspFace.v
@@ -1,0 +1,215 @@
+(** * Q3 BSP face/surface type with lump parser.
+
+    Defines the face/surface lump of the Q3 BSP format:
+
+    - **Faces lump** (lump index 13): each entry is a surface record
+      describing a renderable face.  It references texture, effect,
+      vertex, and mesh-vertex indices, lightmap placement, surface
+      normal, and (for patches) the control-point grid dimensions.
+      Entry size: 104 bytes (26 × 4 bytes: a mix of i32 and f32).
+
+    The [fc_type] field distinguishes four surface types:
+    - 1 = polygon
+    - 2 = Bézier patch
+    - 3 = triangle mesh
+    - 4 = billboard (axis-aligned sprite)
+
+    All integer fields are 32-bit signed little-endian.  All float
+    fields are IEEE 754 single-precision little-endian, decoded to
+    exact [Q] rationals.  Byte offsets follow the Q3 BSP specification
+    exactly. *)
+
+From Stdlib Require Import List.
+From Stdlib Require Import ZArith.
+From Stdlib Require Import QArith.
+From Bsp Require Import BspBinary.
+Import ListNotations.
+Open Scope Z_scope.
+
+(* ------------------------------------------------------------------ *)
+(** ** Face / surface                                                   *)
+(* ------------------------------------------------------------------ *)
+
+(** A single entry in the faces lump.
+
+    Field layout (offsets relative to entry start):
+    - [fc_texture]:     bytes   0–  3  (texture index)
+    - [fc_effect]:      bytes   4–  7  (effect index; -1 = none)
+    - [fc_type]:        bytes   8– 11  (face type: 1–4)
+    - [fc_vertex]:      bytes  12– 15  (first vertex index)
+    - [fc_n_vertexes]:  bytes  16– 19  (number of vertices)
+    - [fc_meshvert]:    bytes  20– 23  (first mesh-vertex index)
+    - [fc_n_meshverts]: bytes  24– 27  (number of mesh-vertices)
+    - [fc_lm_index]:    bytes  28– 31  (lightmap index; -1 = none)
+    - [fc_lm_start_x]:  bytes  32– 35  (lightmap corner X in atlas)
+    - [fc_lm_start_y]:  bytes  36– 39  (lightmap corner Y in atlas)
+    - [fc_lm_size_x]:   bytes  40– 43  (lightmap width in texels)
+    - [fc_lm_size_y]:   bytes  44– 47  (lightmap height in texels)
+    - [fc_lm_origin_x]: bytes  48– 51  (world-space lightmap origin X, f32)
+    - [fc_lm_origin_y]: bytes  52– 55  (world-space lightmap origin Y, f32)
+    - [fc_lm_origin_z]: bytes  56– 59  (world-space lightmap origin Z, f32)
+    - [fc_lm_vecs_s_x]: bytes  60– 63  (lightmap S-axis X, f32)
+    - [fc_lm_vecs_s_y]: bytes  64– 67  (lightmap S-axis Y, f32)
+    - [fc_lm_vecs_s_z]: bytes  68– 71  (lightmap S-axis Z, f32)
+    - [fc_lm_vecs_t_x]: bytes  72– 75  (lightmap T-axis X, f32)
+    - [fc_lm_vecs_t_y]: bytes  76– 79  (lightmap T-axis Y, f32)
+    - [fc_lm_vecs_t_z]: bytes  80– 83  (lightmap T-axis Z, f32)
+    - [fc_normal_x]:    bytes  84– 87  (surface normal X, f32)
+    - [fc_normal_y]:    bytes  88– 91  (surface normal Y, f32)
+    - [fc_normal_z]:    bytes  92– 95  (surface normal Z, f32)
+    - [fc_size_x]:      bytes  96– 99  (patch grid width, i32)
+    - [fc_size_y]:      bytes 100–103  (patch grid height, i32) *)
+Record bsp_face : Type := mk_bsp_face
+  { fc_texture     : Z
+  ; fc_effect      : Z
+  ; fc_type        : Z
+  ; fc_vertex      : Z
+  ; fc_n_vertexes  : Z
+  ; fc_meshvert    : Z
+  ; fc_n_meshverts : Z
+  ; fc_lm_index    : Z
+  ; fc_lm_start_x  : Z
+  ; fc_lm_start_y  : Z
+  ; fc_lm_size_x   : Z
+  ; fc_lm_size_y   : Z
+  ; fc_lm_origin_x : Q
+  ; fc_lm_origin_y : Q
+  ; fc_lm_origin_z : Q
+  ; fc_lm_vecs_s_x : Q
+  ; fc_lm_vecs_s_y : Q
+  ; fc_lm_vecs_s_z : Q
+  ; fc_lm_vecs_t_x : Q
+  ; fc_lm_vecs_t_y : Q
+  ; fc_lm_vecs_t_z : Q
+  ; fc_normal_x    : Q
+  ; fc_normal_y    : Q
+  ; fc_normal_z    : Q
+  ; fc_size_x      : Z
+  ; fc_size_y      : Z
+  }.
+
+(** Size of one faces-lump entry in bytes (26 × 4). *)
+Definition bsp_face_size : nat := 104.
+
+(** [parse_bsp_face bs i] reads one 104-byte face entry from byte
+    offset [i] in [bs].  Returns [None] if there are fewer than 104
+    bytes available at that offset. *)
+Definition parse_bsp_face (bs : bytes) (i : nat) : option bsp_face :=
+  match get_i32_le bs  i,
+        get_i32_le bs (i +   4)%nat,
+        get_i32_le bs (i +   8)%nat,
+        get_i32_le bs (i +  12)%nat,
+        get_i32_le bs (i +  16)%nat,
+        get_i32_le bs (i +  20)%nat,
+        get_i32_le bs (i +  24)%nat,
+        get_i32_le bs (i +  28)%nat,
+        get_i32_le bs (i +  32)%nat,
+        get_i32_le bs (i +  36)%nat,
+        get_i32_le bs (i +  40)%nat,
+        get_i32_le bs (i +  44)%nat,
+        get_f32_le bs (i +  48)%nat,
+        get_f32_le bs (i +  52)%nat,
+        get_f32_le bs (i +  56)%nat,
+        get_f32_le bs (i +  60)%nat,
+        get_f32_le bs (i +  64)%nat,
+        get_f32_le bs (i +  68)%nat,
+        get_f32_le bs (i +  72)%nat,
+        get_f32_le bs (i +  76)%nat,
+        get_f32_le bs (i +  80)%nat,
+        get_f32_le bs (i +  84)%nat,
+        get_f32_le bs (i +  88)%nat,
+        get_f32_le bs (i +  92)%nat,
+        get_i32_le bs (i +  96)%nat,
+        get_i32_le bs (i + 100)%nat with
+  | Some tex,  Some eff,  Some typ,
+    Some vtx,  Some nvtx, Some mvt,  Some nmvt,
+    Some lmi,  Some lsx,  Some lsy,  Some lwx,  Some lwy,
+    Some lox,  Some loy,  Some loz,
+    Some lssx, Some lssy, Some lssz,
+    Some lstx, Some lsty, Some lstz,
+    Some nx,   Some ny,   Some nz,
+    Some sx,   Some sy =>
+      Some (mk_bsp_face tex eff typ vtx nvtx mvt nmvt
+                         lmi lsx lsy lwx lwy
+                         lox loy loz
+                         lssx lssy lssz
+                         lstx lsty lstz
+                         nx ny nz sx sy)
+  | _, _, _, _, _, _, _, _, _, _, _, _, _,
+    _, _, _, _, _, _, _, _, _, _, _, _, _ => None
+  end.
+
+(** [parse_face_lump bs off count] reads [count] consecutive face
+    entries from byte offset [off] in [bs].  Returns [None] if any
+    entry cannot be read. *)
+Fixpoint parse_face_lump (bs : bytes) (off : nat) (count : nat)
+    : option (list bsp_face) :=
+  match count with
+  | O    => Some []
+  | S n  =>
+      match parse_bsp_face bs off,
+            parse_face_lump bs (off + bsp_face_size)%nat n with
+      | Some fc, Some rest => Some (fc :: rest)
+      | _, _               => None
+      end
+  end.
+
+(* ------------------------------------------------------------------ *)
+(** ** Correctness lemmas                                               *)
+(* ------------------------------------------------------------------ *)
+
+(** Parsing zero entries always succeeds and returns an empty list. *)
+Lemma parse_face_lump_zero : forall bs off,
+  parse_face_lump bs off 0 = Some [].
+Proof. reflexivity. Qed.
+
+(** [bsp_face_size] is 104. *)
+Lemma bsp_face_size_eq : bsp_face_size = 104%nat.
+Proof. reflexivity. Qed.
+
+(** Parsing a buffer that is too short returns [None]. *)
+Lemma parse_bsp_face_too_short :
+  parse_bsp_face [] 0 = None.
+Proof. reflexivity. Qed.
+
+(** 104 zero bytes decode as a face whose integer fields are all zero
+    and whose float fields are all Qeq to zero. *)
+Lemma parse_bsp_face_zeros :
+  match parse_bsp_face
+    [0;0;0;0; 0;0;0;0; 0;0;0;0; 0;0;0;0;
+     0;0;0;0; 0;0;0;0; 0;0;0;0; 0;0;0;0;
+     0;0;0;0; 0;0;0;0; 0;0;0;0; 0;0;0;0;
+     0;0;0;0; 0;0;0;0; 0;0;0;0; 0;0;0;0;
+     0;0;0;0; 0;0;0;0; 0;0;0;0; 0;0;0;0;
+     0;0;0;0; 0;0;0;0; 0;0;0;0; 0;0;0;0;
+     0;0;0;0; 0;0;0;0; 0;0;0;0; 0;0;0;0] 0 with
+  | Some fc =>
+      fc_texture     fc = 0 /\
+      fc_effect      fc = 0 /\
+      fc_type        fc = 0 /\
+      fc_vertex      fc = 0 /\
+      fc_n_vertexes  fc = 0 /\
+      fc_meshvert    fc = 0 /\
+      fc_n_meshverts fc = 0 /\
+      fc_lm_index    fc = 0 /\
+      fc_lm_start_x  fc = 0 /\
+      fc_lm_start_y  fc = 0 /\
+      fc_lm_size_x   fc = 0 /\
+      fc_lm_size_y   fc = 0 /\
+      (fc_lm_origin_x fc == 0)%Q /\
+      (fc_lm_origin_y fc == 0)%Q /\
+      (fc_lm_origin_z fc == 0)%Q /\
+      (fc_lm_vecs_s_x fc == 0)%Q /\
+      (fc_lm_vecs_s_y fc == 0)%Q /\
+      (fc_lm_vecs_s_z fc == 0)%Q /\
+      (fc_lm_vecs_t_x fc == 0)%Q /\
+      (fc_lm_vecs_t_y fc == 0)%Q /\
+      (fc_lm_vecs_t_z fc == 0)%Q /\
+      (fc_normal_x    fc == 0)%Q /\
+      (fc_normal_y    fc == 0)%Q /\
+      (fc_normal_z    fc == 0)%Q /\
+      fc_size_x      fc = 0 /\
+      fc_size_y      fc = 0
+  | None => False
+  end.
+Proof. vm_compute. repeat split; reflexivity. Qed.

--- a/theories/BspFile.v
+++ b/theories/BspFile.v
@@ -6,8 +6,8 @@
     [None] on any parse failure.
 
     Lumps with dedicated typed parsers are stored as typed lists.
-    Lumps without a typed parser yet (faces, light-volumes) are stored
-    as raw byte slices so no data is lost. *)
+    Lumps without a typed parser yet (light-volumes) are stored as raw
+    byte slices so no data is lost. *)
 
 From Stdlib Require Import List.
 From Stdlib Require Import ZArith.
@@ -18,6 +18,7 @@ From Bsp Require Import BspPlaneVertex.
 From Bsp Require Import BspNodeLeaf.
 From Bsp Require Import BspTexture.
 From Bsp Require Import BspBrush.
+From Bsp Require Import BspFace.
 From Bsp Require Import BspLightmapVisEffect.
 From Bsp Require Import BspEntity.
 Import ListNotations.
@@ -73,7 +74,7 @@ Record bsp_file : Type := mk_bsp_file
   ; bf_vertexes    : list bsp_vertex
   ; bf_mesh_verts  : list Z
   ; bf_effects     : list bsp_effect
-  ; bf_faces       : list Z           (** raw bytes -- typed parser pending *)
+  ; bf_faces       : list bsp_face
   ; bf_lightmaps   : list bsp_lightmap
   ; bf_light_vols  : list Z           (** raw bytes -- typed parser pending *)
   ; bf_vis_data    : option bsp_vis_data
@@ -130,14 +131,14 @@ Definition parse_bsp_file (bs : bytes) : option bsp_file :=
             parse_vertex_lump    bs (off e_vtx) (cnt e_vtx bsp_vertex_size),
             parse_i32_lump       bs (off e_mvt) (cnt e_mvt 4%nat),
             parse_effect_lump    bs (off e_efx) (cnt e_efx bsp_effect_size),
-            slice                bs (off e_fac) (len e_fac),
+            parse_face_lump      bs (off e_fac) (cnt e_fac bsp_face_size),
             parse_lightmap_lump  bs (off e_lmp) (cnt e_lmp bsp_lightmap_size),
             slice                bs (off e_lvl) (len e_lvl) with
       | Some textures,  Some planes,     Some nodes,
         Some leaves,    Some leaf_faces, Some leaf_brushes,
         Some models,    Some brushes,    Some brush_sides,
         Some vertexes,  Some mesh_verts, Some effects,
-        Some faces_raw, Some lightmaps,  Some lvols_raw =>
+        Some faces,     Some lightmaps,  Some lvols_raw =>
           (* vis data: optional -- zero-length lump is valid *)
           let vis :=
             if (len e_vis =? 0)%nat then Some None
@@ -151,7 +152,7 @@ Definition parse_bsp_file (bs : bytes) : option bsp_file :=
                                 leaves leaf_faces leaf_brushes
                                 models brushes brush_sides
                                 vertexes mesh_verts effects
-                                faces_raw lightmaps lvols_raw vis_opt)
+                                faces lightmaps lvols_raw vis_opt)
           | None => None
           end
       | _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ => None

--- a/theories/BspProofs.v
+++ b/theories/BspProofs.v
@@ -30,6 +30,7 @@ From Bsp Require Import BspPlaneVertex.
 From Bsp Require Import BspNodeLeaf.
 From Bsp Require Import BspTexture.
 From Bsp Require Import BspBrush.
+From Bsp Require Import BspFace.
 From Bsp Require Import BspLightmapVisEffect.
 From Bsp Require Import BspEntity.
 From Bsp Require Import BspFile.
@@ -354,6 +355,13 @@ Theorem parse_effect_lump_length : forall bs off count es,
   parse_effect_lump bs off count = Some es -> length es = count.
 Proof.
   apply (lump_length_generic parse_bsp_effect bsp_effect_size);
+    intros; reflexivity.
+Qed.
+
+Theorem parse_face_lump_length : forall bs off count fs,
+  parse_face_lump bs off count = Some fs -> length fs = count.
+Proof.
+  apply (lump_length_generic parse_bsp_face bsp_face_size);
     intros; reflexivity.
 Qed.
 

--- a/theories/BspProofs.v
+++ b/theories/BspProofs.v
@@ -565,6 +565,47 @@ Definition leaves_brushes_valid (f : bsp_file) : bool :=
     (lf_first_leaf_brush l + lf_num_leaf_brushes l <=? nb))
     (bf_leaves f).
 
+(** All face texture indices reference valid textures. *)
+Definition faces_textures_valid (f : bsp_file) : bool :=
+  let nt := Z.of_nat (length (bf_textures f)) in
+  forallb (fun fc =>
+    (0 <=? fc_texture fc) && (fc_texture fc <? nt))
+    (bf_faces f).
+
+(** All face effect indices reference valid effects, or are -1 (none). *)
+Definition faces_effects_valid (f : bsp_file) : bool :=
+  let ne := Z.of_nat (length (bf_effects f)) in
+  forallb (fun fc =>
+    (fc_effect fc =? -1) ||
+    ((0 <=? fc_effect fc) && (fc_effect fc <? ne)))
+    (bf_faces f).
+
+(** All face vertex-ranges stay within the vertexes lump. *)
+Definition faces_vertexes_valid (f : bsp_file) : bool :=
+  let nv := Z.of_nat (length (bf_vertexes f)) in
+  forallb (fun fc =>
+    (0 <=? fc_vertex fc) &&
+    (0 <=? fc_n_vertexes fc) &&
+    (fc_vertex fc + fc_n_vertexes fc <=? nv))
+    (bf_faces f).
+
+(** All face mesh-vertex-ranges stay within the mesh-verts lump. *)
+Definition faces_meshverts_valid (f : bsp_file) : bool :=
+  let nm := Z.of_nat (length (bf_mesh_verts f)) in
+  forallb (fun fc =>
+    (0 <=? fc_meshvert fc) &&
+    (0 <=? fc_n_meshverts fc) &&
+    (fc_meshvert fc + fc_n_meshverts fc <=? nm))
+    (bf_faces f).
+
+(** All face lightmap indices reference valid lightmaps, or are -1 (none). *)
+Definition faces_lightmaps_valid (f : bsp_file) : bool :=
+  let nl := Z.of_nat (length (bf_lightmaps f)) in
+  forallb (fun fc =>
+    (fc_lm_index fc =? -1) ||
+    ((0 <=? fc_lm_index fc) && (fc_lm_index fc <? nl)))
+    (bf_faces f).
+
 (** All model face-ranges are non-negative. *)
 Definition models_faces_valid (f : bsp_file) : bool :=
   forallb (fun m =>
@@ -591,6 +632,11 @@ Definition bsp_cross_lump_valid (f : bsp_file) : bool :=
   brushes_textures_valid f &&
   brushes_sides_valid f &&
   effects_brushes_valid f &&
+  faces_textures_valid f &&
+  faces_effects_valid f &&
+  faces_vertexes_valid f &&
+  faces_meshverts_valid f &&
+  faces_lightmaps_valid f &&
   leaves_faces_valid f &&
   leaves_brushes_valid f &&
   models_faces_valid f &&
@@ -609,7 +655,7 @@ Local Ltac reflect_andb2 :=
   intros f Hv x Hin;
   unfold nodes_planes_valid, brush_sides_planes_valid,
          brush_sides_textures_valid, brushes_textures_valid,
-         effects_brushes_valid in Hv;
+         effects_brushes_valid, faces_textures_valid in Hv;
   rewrite forallb_forall in Hv;
   specialize (Hv x Hin);
   rewrite Bool.andb_true_iff in Hv;
@@ -647,6 +693,12 @@ Theorem effects_brushes_valid_correct : forall f,
   0 <= fx_brush_index e < Z.of_nat (length (bf_brushes f)).
 Proof. reflect_andb2. Qed.
 
+Theorem faces_textures_valid_correct : forall f,
+  faces_textures_valid f = true ->
+  forall fc, In fc (bf_faces f) ->
+  0 <= fc_texture fc < Z.of_nat (length (bf_textures f)).
+Proof. reflect_andb2. Qed.
+
 (** Helper: reflect a three-conjunct range-check boolean into [Prop]. *)
 Local Ltac reflect_range3 unfold_name :=
   intros f Hv x Hin;
@@ -660,6 +712,35 @@ Local Ltac reflect_range3 unfold_name :=
   | apply Z.leb_le; exact Hnum
   | apply Z.leb_le; exact Hsum ].
 
+(** Helper: reflect an optional-index boolean check (value = -1 or
+    0 <= value < bound) into [Prop]. *)
+Local Ltac reflect_optional unfold_name field :=
+  intros f Hv x Hin;
+  unfold unfold_name in Hv;
+  rewrite forallb_forall in Hv;
+  specialize (Hv x Hin);
+  rewrite Bool.orb_true_iff in Hv;
+  destruct Hv as [Heq | Hrange];
+  [ left; apply Z.eqb_eq; exact Heq
+  | right; rewrite Bool.andb_true_iff in Hrange;
+    destruct Hrange as [Hle Hlt];
+    split; [ apply Z.leb_le; exact Hle
+           | apply Z.ltb_lt; exact Hlt ] ].
+
+Theorem faces_effects_valid_correct : forall f,
+  faces_effects_valid f = true ->
+  forall fc, In fc (bf_faces f) ->
+  fc_effect fc = -1 \/
+  0 <= fc_effect fc < Z.of_nat (length (bf_effects f)).
+Proof. reflect_optional faces_effects_valid fc_effect. Qed.
+
+Theorem faces_lightmaps_valid_correct : forall f,
+  faces_lightmaps_valid f = true ->
+  forall fc, In fc (bf_faces f) ->
+  fc_lm_index fc = -1 \/
+  0 <= fc_lm_index fc < Z.of_nat (length (bf_lightmaps f)).
+Proof. reflect_optional faces_lightmaps_valid fc_lm_index. Qed.
+
 Theorem brushes_sides_valid_correct : forall f,
   brushes_sides_valid f = true ->
   forall b, In b (bf_brushes f) ->
@@ -668,6 +749,24 @@ Theorem brushes_sides_valid_correct : forall f,
   br_first_side b + br_num_sides b <=
     Z.of_nat (length (bf_brush_sides f)).
 Proof. reflect_range3 brushes_sides_valid. Qed.
+
+Theorem faces_vertexes_valid_correct : forall f,
+  faces_vertexes_valid f = true ->
+  forall fc, In fc (bf_faces f) ->
+  0 <= fc_vertex fc /\
+  0 <= fc_n_vertexes fc /\
+  fc_vertex fc + fc_n_vertexes fc <=
+    Z.of_nat (length (bf_vertexes f)).
+Proof. reflect_range3 faces_vertexes_valid. Qed.
+
+Theorem faces_meshverts_valid_correct : forall f,
+  faces_meshverts_valid f = true ->
+  forall fc, In fc (bf_faces f) ->
+  0 <= fc_meshvert fc /\
+  0 <= fc_n_meshverts fc /\
+  fc_meshvert fc + fc_n_meshverts fc <=
+    Z.of_nat (length (bf_mesh_verts f)).
+Proof. reflect_range3 faces_meshverts_valid. Qed.
 
 Theorem leaves_faces_valid_correct : forall f,
   leaves_faces_valid f = true ->
@@ -709,14 +808,38 @@ Theorem bsp_cross_lump_valid_sound : forall f,
   (forall b, In b (bf_brushes f) ->
      0 <= br_texture_index b < Z.of_nat (length (bf_textures f))) /\
   (forall e, In e (bf_effects f) ->
-     0 <= fx_brush_index e < Z.of_nat (length (bf_brushes f))).
+     0 <= fx_brush_index e < Z.of_nat (length (bf_brushes f))) /\
+  (forall fc, In fc (bf_faces f) ->
+     0 <= fc_texture fc < Z.of_nat (length (bf_textures f))) /\
+  (forall fc, In fc (bf_faces f) ->
+     fc_effect fc = -1 \/
+     0 <= fc_effect fc < Z.of_nat (length (bf_effects f))) /\
+  (forall fc, In fc (bf_faces f) ->
+     0 <= fc_vertex fc /\
+     0 <= fc_n_vertexes fc /\
+     fc_vertex fc + fc_n_vertexes fc <=
+       Z.of_nat (length (bf_vertexes f))) /\
+  (forall fc, In fc (bf_faces f) ->
+     0 <= fc_meshvert fc /\
+     0 <= fc_n_meshverts fc /\
+     fc_meshvert fc + fc_n_meshverts fc <=
+       Z.of_nat (length (bf_mesh_verts f))) /\
+  (forall fc, In fc (bf_faces f) ->
+     fc_lm_index fc = -1 \/
+     0 <= fc_lm_index fc < Z.of_nat (length (bf_lightmaps f))).
 Proof.
   intros f Hv. unfold bsp_cross_lump_valid in Hv.
   repeat rewrite Bool.andb_true_iff in Hv.
-  destruct Hv as [[[[[[[[[Hn Hbsp] Hbst] Hbt] Hbs] Heb] _] _] _] _].
+  destruct Hv as [[[[[[[[[[[[[[Hn Hbsp] Hbst] Hbt] Hbs] Heb]
+    Hft] Hfe] Hfv] Hfm] Hfl] _] _] _] _].
   exact (conj (nodes_planes_valid_correct f Hn)
         (conj (brush_sides_planes_valid_correct f Hbsp)
         (conj (brush_sides_textures_valid_correct f Hbst)
         (conj (brushes_textures_valid_correct f Hbt)
-              (effects_brushes_valid_correct f Heb))))).
+        (conj (effects_brushes_valid_correct f Heb)
+        (conj (faces_textures_valid_correct f Hft)
+        (conj (faces_effects_valid_correct f Hfe)
+        (conj (faces_vertexes_valid_correct f Hfv)
+        (conj (faces_meshverts_valid_correct f Hfm)
+              (faces_lightmaps_valid_correct f Hfl)))))))))).
 Qed.


### PR DESCRIPTION
Fixes #24.

Adds BSP face parsing and cross-lump validity proofs in Rocq, then builds the JS-side binary reader and WebGL renderer with lightmap support. Finishes by wiring up the asset pipeline and adding a fly camera for level inspection.

---

- [ ] Build JS BSP binary reader from loaded asset buffers
- [ ] Implement WebGL renderer for BSP face geometry with lightmaps
- [ ] Wire asset loading to render pipeline and remove placeholder
- [ ] Add keyboard and mouse fly camera for level inspection