### PR TITLE
Port player movement, camera, collision, and desktop/mobile input (closes #25)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -59,6 +59,22 @@ player state, advances physics, evaluates triggers, and produces a
 **render snapshot** (camera transform, visible surface list, entity
 positions) that JavaScript consumes for drawing.
 
+For player controls, the frame-step contract is intentionally specific:
+
+- JavaScript normalizes desktop keyboard/mouse and mobile touch controls
+  into the same `input_snapshot` shape before crossing the bridge.
+- Rocq applies yaw deltas before deriving planar movement, so "forward"
+  and "strafe" always mean relative to the updated facing angle.
+- Rocq clamps pitch to the gameplay-safe range and wraps yaw into the
+  usual turn-around interval rather than leaving angle drift to JS.
+- World stepping owns jump, gravity, and collision response: jumping is
+  grounded-only, gravity applies when airborne, and blocked motion zeroes
+  the corresponding velocity component in the authoritative state.
+
+These rules are documented as executable lemmas and examples in
+`theories/GameState.v`, so the shipped controls have a proof-backed
+behavior story instead of only an informal browser implementation.
+
 ## What stays in JavaScript
 
 These responsibilities stay in the browser shell because they require

--- a/V1_CHECKLIST.md
+++ b/V1_CHECKLIST.md
@@ -110,6 +110,9 @@ Many Deaths").  Reasons:
 - [ ] All game state (player position, orientation, velocity, entity state)
       lives in Rocq.  JavaScript reads render snapshots; it never independently
       tracks or recomputes game state.
+- [ ] `theories/GameState.v` includes executable proofs/examples for the control
+      contract: pitch clamping, yaw-relative movement, conflicting-axis
+      cancellation, grounded jumping, and airborne gravity.
 - [ ] The Rocq theories that power the running game are visible and
       step-through-able in the JsCoq IDE panel on the same page.
 - [ ] `make test` (CI: `rocq compile`) passes with the game-core theories in

--- a/docs/index.html
+++ b/docs/index.html
@@ -263,6 +263,7 @@
 
   <script type="module">
     import { parseBsp } from './bsp.js';
+    import { createDesktopInput } from './input.js';
     import { createRenderer, mat4Perspective } from './renderer.js';
     import { createRocqBridge } from './rocq_bridge.js';
     import { loadShadersFromAssets } from './shaders.js';
@@ -478,9 +479,15 @@
         document.getElementById('game-placeholder').hidden = true;
 
         const projMatrix = new Float32Array(16);
+        const desktopInput = createDesktopInput(canvas);
+        let lastFrameTime = null;
 
-        async function frame() {
-          const snapshot = await rocqBridge.step(null);
+        async function frame(now) {
+          const dtMs = lastFrameTime === null
+            ? 0
+            : Math.min(100, Math.max(0, now - lastFrameTime));
+          lastFrameTime = now;
+          const snapshot = await rocqBridge.step(desktopInput.sample(dtMs));
           // Update projection each frame to track canvas resize
           const aspect = canvas.width / canvas.height || 1;
           mat4Perspective(projMatrix, Math.PI / 2, aspect, 1.0, 4096.0);

--- a/docs/index.html
+++ b/docs/index.html
@@ -99,6 +99,7 @@
       width: 100%;
       height: 100%;
       /* canvas intrinsic size is set by JS; CSS fills the container */
+      touch-action: none;
     }
     #game-placeholder {
       position: absolute;
@@ -115,6 +116,130 @@
     #game-placeholder .label {
       font-size: 1.5rem;
       color: #222;
+    }
+
+    #game-overlay {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      padding:
+        max(0.75rem, env(safe-area-inset-top))
+        max(0.75rem, env(safe-area-inset-right))
+        max(0.75rem, env(safe-area-inset-bottom))
+        max(0.75rem, env(safe-area-inset-left));
+      pointer-events: none;
+    }
+
+    #game-hint {
+      align-self: center;
+      max-width: min(32rem, calc(100% - 2rem));
+      padding: 0.45rem 0.8rem;
+      border-radius: 999px;
+      background: rgb(7 10 20 / 72%);
+      border: 1px solid rgb(160 196 255 / 28%);
+      color: #d7e7ff;
+      font-size: 0.78rem;
+      text-align: center;
+      backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
+    }
+
+    #game-hint-mobile { display: none; }
+
+    #touch-controls {
+      display: none;
+      width: 100%;
+      align-items: flex-end;
+      justify-content: space-between;
+      gap: 1rem;
+      margin-top: auto;
+    }
+
+    .touch-cluster {
+      display: flex;
+      gap: 0.9rem;
+      align-items: flex-end;
+    }
+
+    .touch-cluster.right {
+      flex-direction: column;
+      align-items: flex-end;
+    }
+
+    .touch-pad {
+      position: relative;
+      width: clamp(6.5rem, 24vw, 9rem);
+      height: clamp(6.5rem, 24vw, 9rem);
+      border-radius: 50%;
+      border: 1px solid rgb(160 196 255 / 24%);
+      background: rgb(7 10 20 / 52%);
+      box-shadow: inset 0 0 0 1px rgb(255 255 255 / 4%);
+      pointer-events: auto;
+      touch-action: none;
+      overflow: hidden;
+      backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
+    }
+
+    .touch-pad::before {
+      content: '';
+      position: absolute;
+      inset: 18%;
+      border-radius: 50%;
+      border: 1px solid rgb(160 196 255 / 14%);
+    }
+
+    .touch-pad-label {
+      position: absolute;
+      left: 50%;
+      bottom: 0.65rem;
+      transform: translateX(-50%);
+      font-size: 0.72rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #9db7df;
+      pointer-events: none;
+    }
+
+    .touch-knob {
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      width: 38%;
+      height: 38%;
+      border-radius: 50%;
+      transform: translate(0, 0);
+      margin-left: -19%;
+      margin-top: -19%;
+      background: rgb(160 196 255 / 34%);
+      border: 1px solid rgb(255 255 255 / 14%);
+      box-shadow: 0 0 20px rgb(0 0 0 / 25%);
+      pointer-events: none;
+    }
+
+    #jump-button {
+      min-width: clamp(4.5rem, 16vw, 5.75rem);
+      min-height: clamp(4.5rem, 16vw, 5.75rem);
+      padding: 0.8rem 1rem;
+      border: 1px solid rgb(160 196 255 / 28%);
+      border-radius: 999px;
+      background: rgb(7 10 20 / 64%);
+      color: #d7e7ff;
+      font: inherit;
+      font-size: 0.86rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      pointer-events: auto;
+      touch-action: none;
+      backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
+    }
+
+    #jump-button:active {
+      background: rgb(45 76 126 / 72%);
     }
 
     /* ── drag-to-resize handle ───────────────────────────────── */
@@ -197,6 +322,22 @@
         border-top: none;
         border-left: 2px solid #2a2a4e;
       }
+
+      #game-hint {
+        align-self: flex-start;
+        max-width: 18rem;
+        font-size: 0.72rem;
+      }
+
+      .touch-pad {
+        width: clamp(5.2rem, 20vh, 7rem);
+        height: clamp(5.2rem, 20vh, 7rem);
+      }
+
+      #jump-button {
+        min-width: clamp(4rem, 14vh, 5rem);
+        min-height: clamp(4rem, 14vh, 5rem);
+      }
     }
 
     /* ══════════════════════════════════════════════════════════
@@ -220,6 +361,12 @@
         border-left: 2px solid #2a2a4e;
       }
     }
+
+    @media (pointer: coarse) {
+      #game-hint-desktop { display: none; }
+      #game-hint-mobile { display: inline; }
+      #touch-controls { display: flex; }
+    }
   </style>
 </head>
 <body>
@@ -231,13 +378,36 @@
   <!-- status bar: shows loading progress and surfaces errors in the UI -->
   <div id="status-bar" role="alert" aria-live="polite" hidden></div>
 
-  <div id="main">
-    <!-- ── game canvas (Quake rendering target: issues #15, #16) ── -->
-    <div id="game-surface">
-      <canvas id="game-canvas" aria-label="Game surface"></canvas>
-      <div id="game-placeholder">
-        <span class="label">[ game canvas ]</span>
-        <span>Quake rendering target — coming in <a href="https://github.com/rhencke/orly/issues/15" style="color:#444">#15</a></span>
+    <div id="main">
+      <!-- ── game canvas (Quake rendering target: issues #15, #16) ── -->
+      <div id="game-surface">
+        <canvas id="game-canvas" aria-label="Game surface"></canvas>
+        <div id="game-overlay">
+          <div id="game-hint">
+            <span id="game-hint-desktop">Click to look. WASD moves. Space jumps.</span>
+            <span id="game-hint-mobile">Left pad moves. Right pad looks. Tap jump.</span>
+          </div>
+          <div id="touch-controls" hidden>
+            <div class="touch-cluster left">
+              <div class="touch-pad" data-touch-control="move-pad" aria-label="Movement control">
+                <div class="touch-knob" data-touch-control="move-knob"></div>
+                <span class="touch-pad-label">Move</span>
+              </div>
+            </div>
+            <div class="touch-cluster right">
+              <button id="jump-button" data-touch-control="jump" type="button" aria-label="Jump">
+                Jump
+              </button>
+              <div class="touch-pad" data-touch-control="look-pad" aria-label="Look control">
+                <div class="touch-knob" data-touch-control="look-knob"></div>
+                <span class="touch-pad-label">Look</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div id="game-placeholder">
+          <span class="label">[ game canvas ]</span>
+          <span>Quake rendering target — coming in <a href="https://github.com/rhencke/orly/issues/15" style="color:#444">#15</a></span>
       </div>
     </div>
 
@@ -263,7 +433,7 @@
 
   <script type="module">
     import { parseBsp } from './bsp.js';
-    import { createDesktopInput } from './input.js';
+    import { createPlayerInput } from './input.js';
     import { createRenderer, mat4Perspective } from './renderer.js';
     import { createRocqBridge } from './rocq_bridge.js';
     import { loadShadersFromAssets } from './shaders.js';
@@ -436,6 +606,7 @@
     // Keep the canvas pixel dimensions in sync with its CSS layout size
     // so the renderer gets a correctly sized drawing surface.
     const canvas = document.getElementById('game-canvas');
+    const touchOverlay = document.getElementById('touch-controls');
 
     // ── BSP parse + render pipeline ──────────────────────────────
     // If the BSP file was loaded, parse it and start the renderer.
@@ -479,7 +650,7 @@
         document.getElementById('game-placeholder').hidden = true;
 
         const projMatrix = new Float32Array(16);
-        const desktopInput = createDesktopInput(canvas);
+        const playerInput = createPlayerInput(canvas, touchOverlay);
         let lastFrameTime = null;
 
         async function frame(now) {
@@ -487,7 +658,7 @@
             ? 0
             : Math.min(100, Math.max(0, now - lastFrameTime));
           lastFrameTime = now;
-          const snapshot = await rocqBridge.step(desktopInput.sample(dtMs));
+          const snapshot = await rocqBridge.step(playerInput.sample(dtMs));
           // Update projection each frame to track canvas resize
           const aspect = canvas.width / canvas.height || 1;
           mat4Perspective(projMatrix, Math.PI / 2, aspect, 1.0, 4096.0);

--- a/docs/index.html
+++ b/docs/index.html
@@ -457,6 +457,9 @@
           entities: bsp.entities,
           faces: bsp.faces,
           textures: bsp.textures,
+          planes: bsp.planes,
+          brushes: bsp.brushes,
+          brushSides: bsp.brushSides,
         });
 
         showStatus('Loading shaders…');

--- a/docs/input.js
+++ b/docs/input.js
@@ -1,4 +1,5 @@
-const MOUSE_SENSITIVITY = 0.15; // degrees per pixel of pointer-lock motion
+const MOUSE_SENSITIVITY = 0.15; // degrees per pixel of look motion
+const TOUCH_AXIS_THRESHOLD = 0.35;
 
 const KEY_FORWARD = new Set(['KeyW', 'ArrowUp']);
 const KEY_BACK = new Set(['KeyS', 'ArrowDown']);
@@ -92,6 +93,203 @@ export function createDesktopInput(canvas) {
       if (document.pointerLockElement === canvas) {
         document.exitPointerLock?.();
       }
+    },
+  };
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function setKnobOffset(knob, dx, dy) {
+  knob.style.transform = `translate(${dx}px, ${dy}px)`;
+}
+
+function createTouchPad(pad, knob, { accumulateLook = false, onPressChange = null } = {}) {
+  let pointerId = null;
+  let axisX = 0;
+  let axisY = 0;
+  let lookDX = 0;
+  let lookDY = 0;
+  let lastX = 0;
+  let lastY = 0;
+
+  function reset() {
+    pointerId = null;
+    axisX = 0;
+    axisY = 0;
+    lookDX = 0;
+    lookDY = 0;
+    setKnobOffset(knob, 0, 0);
+    onPressChange?.(false);
+  }
+
+  function updateAxisFromEvent(event) {
+    const rect = pad.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+    const radius = Math.max(1, Math.min(rect.width, rect.height) * 0.35);
+    const rawX = event.clientX - centerX;
+    const rawY = event.clientY - centerY;
+    const distance = Math.hypot(rawX, rawY);
+    const scale = distance > radius ? radius / distance : 1;
+    const clampedX = rawX * scale;
+    const clampedY = rawY * scale;
+    axisX = clampedX / radius;
+    axisY = clampedY / radius;
+    setKnobOffset(knob, clampedX, clampedY);
+  }
+
+  function onPointerDown(event) {
+    if (event.pointerType === 'mouse') return;
+    if (pointerId !== null) return;
+    pointerId = event.pointerId;
+    lastX = event.clientX;
+    lastY = event.clientY;
+    pad.setPointerCapture?.(event.pointerId);
+    if (!accumulateLook) {
+      updateAxisFromEvent(event);
+    }
+    onPressChange?.(true);
+    event.preventDefault();
+  }
+
+  function onPointerMove(event) {
+    if (event.pointerId !== pointerId) return;
+    if (accumulateLook) {
+      lookDX += event.clientX - lastX;
+      lookDY += event.clientY - lastY;
+      lastX = event.clientX;
+      lastY = event.clientY;
+      updateAxisFromEvent(event);
+    } else {
+      updateAxisFromEvent(event);
+    }
+    event.preventDefault();
+  }
+
+  function onPointerEnd(event) {
+    if (event.pointerId !== pointerId) return;
+    reset();
+    event.preventDefault();
+  }
+
+  pad.addEventListener('pointerdown', onPointerDown);
+  pad.addEventListener('pointermove', onPointerMove);
+  pad.addEventListener('pointerup', onPointerEnd);
+  pad.addEventListener('pointercancel', onPointerEnd);
+
+  return {
+    sample() {
+      const snapshot = {
+        axisX,
+        axisY,
+        yawDelta: -lookDX * MOUSE_SENSITIVITY,
+        pitchDelta: -lookDY * MOUSE_SENSITIVITY,
+      };
+      lookDX = 0;
+      lookDY = 0;
+      return snapshot;
+    },
+
+    destroy() {
+      reset();
+      pad.removeEventListener('pointerdown', onPointerDown);
+      pad.removeEventListener('pointermove', onPointerMove);
+      pad.removeEventListener('pointerup', onPointerEnd);
+      pad.removeEventListener('pointercancel', onPointerEnd);
+    },
+  };
+}
+
+export function createTouchInput(overlay) {
+  const coarsePointerQuery = window.matchMedia('(pointer: coarse)');
+  const movePad = overlay.querySelector('[data-touch-control="move-pad"]');
+  const moveKnob = overlay.querySelector('[data-touch-control="move-knob"]');
+  const lookPad = overlay.querySelector('[data-touch-control="look-pad"]');
+  const lookKnob = overlay.querySelector('[data-touch-control="look-knob"]');
+  const jumpButton = overlay.querySelector('[data-touch-control="jump"]');
+  let jumpPressed = false;
+
+  const moveControl = createTouchPad(movePad, moveKnob);
+  const lookControl = createTouchPad(lookPad, lookKnob, { accumulateLook: true });
+
+  function syncVisibility() {
+    overlay.hidden = !coarsePointerQuery.matches;
+  }
+
+  function onJumpDown(event) {
+    if (event.pointerType === 'mouse') return;
+    jumpPressed = true;
+    jumpButton.setPointerCapture?.(event.pointerId);
+    event.preventDefault();
+  }
+
+  function onJumpEnd(event) {
+    jumpPressed = false;
+    event.preventDefault();
+  }
+
+  syncVisibility();
+  coarsePointerQuery.addEventListener('change', syncVisibility);
+  jumpButton.addEventListener('pointerdown', onJumpDown);
+  jumpButton.addEventListener('pointerup', onJumpEnd);
+  jumpButton.addEventListener('pointercancel', onJumpEnd);
+  window.addEventListener('blur', onJumpEnd);
+
+  return {
+    sample() {
+      const move = moveControl.sample();
+      const look = lookControl.sample();
+      const axisX = clamp(move.axisX, -1, 1);
+      const axisY = clamp(move.axisY, -1, 1);
+      return {
+        forward: axisY < -TOUCH_AXIS_THRESHOLD,
+        back: axisY > TOUCH_AXIS_THRESHOLD,
+        left: axisX < -TOUCH_AXIS_THRESHOLD,
+        right: axisX > TOUCH_AXIS_THRESHOLD,
+        jump: jumpPressed,
+        yawDelta: look.yawDelta,
+        pitchDelta: look.pitchDelta,
+      };
+    },
+
+    destroy() {
+      moveControl.destroy();
+      lookControl.destroy();
+      jumpPressed = false;
+      coarsePointerQuery.removeEventListener('change', syncVisibility);
+      jumpButton.removeEventListener('pointerdown', onJumpDown);
+      jumpButton.removeEventListener('pointerup', onJumpEnd);
+      jumpButton.removeEventListener('pointercancel', onJumpEnd);
+      window.removeEventListener('blur', onJumpEnd);
+    },
+  };
+}
+
+export function createPlayerInput(canvas, overlay) {
+  const desktop = createDesktopInput(canvas);
+  const touch = createTouchInput(overlay);
+
+  return {
+    sample(dtMs) {
+      const desktopSnapshot = desktop.sample(dtMs);
+      const touchSnapshot = touch.sample();
+      return {
+        forward: desktopSnapshot.forward || touchSnapshot.forward,
+        back: desktopSnapshot.back || touchSnapshot.back,
+        left: desktopSnapshot.left || touchSnapshot.left,
+        right: desktopSnapshot.right || touchSnapshot.right,
+        jump: desktopSnapshot.jump || touchSnapshot.jump,
+        yawDelta: desktopSnapshot.yawDelta + touchSnapshot.yawDelta,
+        pitchDelta: desktopSnapshot.pitchDelta + touchSnapshot.pitchDelta,
+        dtMs: desktopSnapshot.dtMs,
+      };
+    },
+
+    destroy() {
+      desktop.destroy();
+      touch.destroy();
     },
   };
 }

--- a/docs/input.js
+++ b/docs/input.js
@@ -1,0 +1,97 @@
+const MOUSE_SENSITIVITY = 0.15; // degrees per pixel of pointer-lock motion
+
+const KEY_FORWARD = new Set(['KeyW', 'ArrowUp']);
+const KEY_BACK = new Set(['KeyS', 'ArrowDown']);
+const KEY_LEFT = new Set(['KeyA', 'ArrowLeft']);
+const KEY_RIGHT = new Set(['KeyD', 'ArrowRight']);
+const KEY_JUMP = new Set(['Space']);
+
+function isEditableTarget(target) {
+  return target instanceof HTMLElement &&
+    (target.tagName === 'TEXTAREA' ||
+     target.tagName === 'INPUT' ||
+     target.isContentEditable);
+}
+
+export function createDesktopInput(canvas) {
+  const pressed = new Set();
+  let mouseDX = 0;
+  let mouseDY = 0;
+
+  function requestPointerLock() {
+    canvas.requestPointerLock?.();
+  }
+
+  function onMouseMove(event) {
+    if (document.pointerLockElement !== canvas) return;
+    mouseDX += event.movementX;
+    mouseDY += event.movementY;
+  }
+
+  function onKeyDown(event) {
+    if (isEditableTarget(event.target)) return;
+    pressed.add(event.code);
+    if (KEY_FORWARD.has(event.code) || KEY_BACK.has(event.code) ||
+        KEY_LEFT.has(event.code) || KEY_RIGHT.has(event.code) ||
+        KEY_JUMP.has(event.code)) {
+      event.preventDefault();
+    }
+  }
+
+  function onKeyUp(event) {
+    pressed.delete(event.code);
+  }
+
+  function clearTransientState() {
+    mouseDX = 0;
+    mouseDY = 0;
+  }
+
+  function clearAllState() {
+    pressed.clear();
+    clearTransientState();
+  }
+
+  function isPressed(keySet) {
+    for (const code of keySet) {
+      if (pressed.has(code)) return true;
+    }
+    return false;
+  }
+
+  canvas.addEventListener('click', requestPointerLock);
+  document.addEventListener('mousemove', onMouseMove);
+  document.addEventListener('keydown', onKeyDown);
+  document.addEventListener('keyup', onKeyUp);
+  document.addEventListener('pointerlockchange', clearAllState);
+  window.addEventListener('blur', clearAllState);
+
+  return {
+    sample(dtMs) {
+      const snapshot = {
+        forward: isPressed(KEY_FORWARD),
+        back: isPressed(KEY_BACK),
+        left: isPressed(KEY_LEFT),
+        right: isPressed(KEY_RIGHT),
+        jump: isPressed(KEY_JUMP),
+        yawDelta: -mouseDX * MOUSE_SENSITIVITY,
+        pitchDelta: -mouseDY * MOUSE_SENSITIVITY,
+        dtMs: Math.max(0, Math.round(dtMs)),
+      };
+      clearTransientState();
+      return snapshot;
+    },
+
+    destroy() {
+      canvas.removeEventListener('click', requestPointerLock);
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('keyup', onKeyUp);
+      document.removeEventListener('pointerlockchange', clearAllState);
+      window.removeEventListener('blur', clearAllState);
+      if (document.pointerLockElement === canvas) {
+        document.exitPointerLock?.();
+      }
+    },
+  };
+}

--- a/docs/rocq_bridge.js
+++ b/docs/rocq_bridge.js
@@ -2,8 +2,9 @@ import { mat4LookAt } from './renderer.js';
 
 const DEG_TO_RAD = Math.PI / 180;
 const BRIDGE_VERSION = 1;
-const BRIDGE_HELPERS_DEFINITION = 'Definition initial_visible_faces_from_inputs';
+const BRIDGE_HELPERS_DEFINITION = 'Definition step_world_words';
 const CAMERA_WORDS_COUNT = 10;
+const GAME_STATE_WORDS_COUNT = 18;
 
 function nextTick() {
   return new Promise(resolve => setTimeout(resolve, 0));
@@ -86,6 +87,59 @@ function cameraSnapshotFromWords(words) {
   };
 }
 
+/**
+ * Extract a camera snapshot from a serialized game-state word list.
+ *
+ * Word layout (see game_state_to_words in GameState.v):
+ *   0-5   position xyz  (three Q rationals, num/den pairs)
+ *   6-11  velocity xyz  (three Q rationals, num/den pairs — not needed here)
+ *   12-13 yaw           (Q rational, num/den)
+ *   14-15 pitch         (Q rational, num/den)
+ *   16    on_ground
+ *   17    tick
+ */
+function cameraSnapshotFromGameStateWords(words) {
+  const toQ = (n, d) => n / d;
+  return {
+    position: {
+      x: toQ(words[0],  words[1]),
+      y: toQ(words[2],  words[3]),
+      z: toQ(words[4],  words[5]),
+    },
+    yaw:   toQ(words[12], words[13]),
+    pitch: toQ(words[14], words[15]),
+  };
+}
+
+function snapshotFromGameStateWords(gsWords, visibleFaces) {
+  const camera = cameraSnapshotFromGameStateWords(gsWords);
+  return {
+    ...camera,
+    visibleFaces: [...visibleFaces],
+    viewMatrix: buildViewMatrix(camera),
+  };
+}
+
+/**
+ * Format a JS input snapshot (or null) as a Rocq input_snapshot expression.
+ * Until keyboard/mouse wiring lands in a later task, null maps to the zero
+ * snapshot so that step calls are valid Rocq before input is plumbed.
+ */
+function formatInputSnapshot(input) {
+  if (!input) return 'input_snapshot_zero';
+  const fmt = b => (b ? 'true' : 'false');
+  const fmtQ = x => {
+    const r = Math.round(x * 1000);
+    return `(${r} # 1000)`;
+  };
+  return `(mk_input_snapshot ` +
+    `${fmt(input.forward)} ${fmt(input.back)} ` +
+    `${fmt(input.left)} ${fmt(input.right)} ` +
+    `${fmt(input.jump)} ` +
+    `${fmtQ(input.yawDelta || 0)} ${fmtQ(input.pitchDelta || 0)} ` +
+    `${Math.round(input.dtMs || 0)})`;
+}
+
 function buildViewMatrix(camera) {
   const viewMatrix = new Float32Array(16);
   const yawRad = camera.yaw * DEG_TO_RAD;
@@ -145,12 +199,17 @@ async function ensureBridgeHelpersReady(manager) {
   throw new Error('Rocq bridge helper definitions were not found in the loaded theory');
 }
 
-async function evalCameraWords(manager, sid, world) {
+async function evalInitialGameStateWords(manager, sid, world) {
   const command =
-    `Eval cbv in (initial_camera_words_from_inputs ` +
-    `${formatEntities(world.entities)} ${formatFaces(world.faces)} ${formatTextures(world.textures)}).`;
+    `Eval cbv in (initial_game_state_words_from_entities ` +
+    `${formatEntities(world.entities)}).`;
   const messages = await manager.coq.queryPromise(sid, ['Vernac', command]);
-  return parseCameraWords(flattenMessages(manager, messages));
+  const words = parseZList(flattenMessages(manager, messages));
+  if (words.length !== GAME_STATE_WORDS_COUNT) {
+    throw new Error(
+      `expected ${GAME_STATE_WORDS_COUNT} game-state words, got ${words.length}`);
+  }
+  return words;
 }
 
 async function evalVisibleFaces(manager, sid, world) {
@@ -161,13 +220,32 @@ async function evalVisibleFaces(manager, sid, world) {
   return parseZList(flattenMessages(manager, messages));
 }
 
+async function evalStepWorldWords(manager, sid, gsWords, inputSnapshot) {
+  const command =
+    `Eval cbv in (step_world_words ` +
+    `${formatZList(gsWords)} ${formatInputSnapshot(inputSnapshot)}).`;
+  const messages = await manager.coq.queryPromise(sid, ['Vernac', command]);
+  const words = parseZList(flattenMessages(manager, messages));
+  if (words.length !== GAME_STATE_WORDS_COUNT) {
+    throw new Error(
+      `expected ${GAME_STATE_WORDS_COUNT} game-state words from step, got ${words.length}`);
+  }
+  return words;
+}
+
 export function createRocqBridge(manager) {
   let bridgeHelpersSidPromise = null;
-  let initialSnapshot = null;
+  let gsWords = null;        // current game-state word list
+  let initialGsWords = null; // snapshot saved at load_world for reset()
+  let visibleFaces = null;   // static visible-face indices (no PVS yet)
 
   function getBridgeHelpersSid() {
     bridgeHelpersSidPromise ||= ensureBridgeHelpersReady(manager);
     return bridgeHelpersSidPromise;
+  }
+
+  function assertLoaded() {
+    if (!gsWords) throw new Error('load_world must run before step/reset');
   }
 
   return {
@@ -175,31 +253,27 @@ export function createRocqBridge(manager) {
 
     async load_world(world) {
       const sid = await getBridgeHelpersSid();
-      const [words, visibleFaces] = await Promise.all([
-        evalCameraWords(manager, sid, world),
+      const [words, faces] = await Promise.all([
+        evalInitialGameStateWords(manager, sid, world),
         evalVisibleFaces(manager, sid, world),
       ]);
-      const camera = cameraSnapshotFromWords(words);
-      initialSnapshot = {
-        ...camera,
-        visibleFaces,
-        viewMatrix: buildViewMatrix(camera),
-      };
-      return cloneSnapshot(initialSnapshot);
+      gsWords        = words;
+      initialGsWords = [...words];
+      visibleFaces   = faces;
+      return snapshotFromGameStateWords(gsWords, visibleFaces);
     },
 
-    async step(_inputSnapshot) {
-      if (!initialSnapshot) {
-        throw new Error('load_world must run before step');
-      }
-      return cloneSnapshot(initialSnapshot);
+    async step(inputSnapshot) {
+      assertLoaded();
+      const sid = await getBridgeHelpersSid();
+      gsWords = await evalStepWorldWords(manager, sid, gsWords, inputSnapshot);
+      return snapshotFromGameStateWords(gsWords, visibleFaces);
     },
 
     async reset() {
-      if (!initialSnapshot) {
-        throw new Error('load_world must run before reset');
-      }
-      return cloneSnapshot(initialSnapshot);
+      assertLoaded();
+      gsWords = [...initialGsWords];
+      return snapshotFromGameStateWords(gsWords, visibleFaces);
     },
   };
 }

--- a/docs/rocq_bridge.js
+++ b/docs/rocq_bridge.js
@@ -176,8 +176,8 @@ function snapshotFromGameStateWords(gsWords, visibleFaces) {
 
 /**
  * Format a JS input snapshot (or null) as a Rocq input_snapshot expression.
- * Until keyboard/mouse wiring lands in a later task, null maps to the zero
- * snapshot so that step calls are valid Rocq before input is plumbed.
+ * Null still maps to the zero snapshot so callers can opt out of driving
+ * movement for a frame without special-case bridge logic.
  */
 function formatInputSnapshot(input) {
   if (!input) return 'input_snapshot_zero';

--- a/docs/rocq_bridge.js
+++ b/docs/rocq_bridge.js
@@ -2,9 +2,12 @@ import { mat4LookAt } from './renderer.js';
 
 const DEG_TO_RAD = Math.PI / 180;
 const BRIDGE_VERSION = 1;
-const BRIDGE_HELPERS_DEFINITION = 'Definition step_world_words';
+const BRIDGE_HELPERS_DEFINITION = 'Definition step_world_words_in_world';
 const CAMERA_WORDS_COUNT = 10;
 const GAME_STATE_WORDS_COUNT = 18;
+const GEOMETRY_Q_SCALE = 1000000;
+const CONTENTS_SOLID = 1;
+const CONTENTS_PLAYERCLIP = 65536;
 
 function nextTick() {
   return new Promise(resolve => setTimeout(resolve, 0));
@@ -20,6 +23,11 @@ function encodeAsciiBytes(str) {
 
 function formatZList(values) {
   return `[${values.join('; ')}]`;
+}
+
+function formatQ(value, scale = GEOMETRY_Q_SCALE) {
+  const numerator = Math.round(value * scale);
+  return `(${numerator} # ${scale})`;
 }
 
 function formatEntity(entity) {
@@ -43,6 +51,14 @@ function formatTextures(textures) {
   return `[${textures.map(formatTexture).join('; ')}]`;
 }
 
+function formatCollisionTexture(texture) {
+  return `(mk_collision_texture_input ${texture.contents})`;
+}
+
+function formatCollisionTextures(textures) {
+  return `[${textures.map(formatCollisionTexture).join('; ')}]`;
+}
+
 function formatFace(face) {
   return `(mk_render_face_input ${face.texture} ${face.type} ${face.nVertexes} ` +
     `${face.nMeshverts} ${face.sizeX} ${face.sizeY})`;
@@ -50,6 +66,44 @@ function formatFace(face) {
 
 function formatFaces(faces) {
   return `[${faces.map(formatFace).join('; ')}]`;
+}
+
+function formatPlane(plane) {
+  return `(mk_collision_plane_input ${formatQ(plane.normalX)} ${formatQ(plane.normalY)} ` +
+    `${formatQ(plane.normalZ)} ${formatQ(plane.dist)})`;
+}
+
+function formatPlanes(planes) {
+  return `[${planes.map(formatPlane).join('; ')}]`;
+}
+
+function formatBrush(brush) {
+  return `(mk_collision_brush_input ${brush.firstSide} ${brush.numSides} ${brush.textureIndex})`;
+}
+
+function formatBrushes(brushes) {
+  return `[${brushes.map(formatBrush).join('; ')}]`;
+}
+
+function formatBrushSide(side) {
+  return `(mk_collision_brush_side_input ${side.planeIndex})`;
+}
+
+function formatBrushSides(brushSides) {
+  return `[${brushSides.map(formatBrushSide).join('; ')}]`;
+}
+
+function formatCollisionWorld(world) {
+  const blockingBrushes = world.brushes.filter(brush => {
+    const texture = world.textures[brush.textureIndex];
+    if (!texture) return false;
+    return (texture.contents & (CONTENTS_SOLID | CONTENTS_PLAYERCLIP)) !== 0;
+  });
+  return `(mk_collision_world_input ` +
+    `${formatPlanes(world.planes)} ` +
+    `${formatCollisionTextures(world.textures)} ` +
+    `${formatBrushes(blockingBrushes)} ` +
+    `${formatBrushSides(world.brushSides)})`;
 }
 
 function flattenMessages(manager, messages) {
@@ -128,15 +182,11 @@ function snapshotFromGameStateWords(gsWords, visibleFaces) {
 function formatInputSnapshot(input) {
   if (!input) return 'input_snapshot_zero';
   const fmt = b => (b ? 'true' : 'false');
-  const fmtQ = x => {
-    const r = Math.round(x * 1000);
-    return `(${r} # 1000)`;
-  };
   return `(mk_input_snapshot ` +
     `${fmt(input.forward)} ${fmt(input.back)} ` +
     `${fmt(input.left)} ${fmt(input.right)} ` +
     `${fmt(input.jump)} ` +
-    `${fmtQ(input.yawDelta || 0)} ${fmtQ(input.pitchDelta || 0)} ` +
+    `${formatQ(input.yawDelta || 0, 1000)} ${formatQ(input.pitchDelta || 0, 1000)} ` +
     `${Math.round(input.dtMs || 0)})`;
 }
 
@@ -201,7 +251,7 @@ async function ensureBridgeHelpersReady(manager) {
 
 async function evalInitialGameStateWords(manager, sid, world) {
   const command =
-    `Eval cbv in (initial_game_state_words_from_entities ` +
+    `Eval vm_compute in (initial_game_state_words_from_entities ` +
     `${formatEntities(world.entities)}).`;
   const messages = await manager.coq.queryPromise(sid, ['Vernac', command]);
   const words = parseZList(flattenMessages(manager, messages));
@@ -214,15 +264,15 @@ async function evalInitialGameStateWords(manager, sid, world) {
 
 async function evalVisibleFaces(manager, sid, world) {
   const command =
-    `Eval cbv in (initial_visible_faces_from_inputs ` +
+    `Eval vm_compute in (initial_visible_faces_from_inputs ` +
     `${formatEntities(world.entities)} ${formatFaces(world.faces)} ${formatTextures(world.textures)}).`;
   const messages = await manager.coq.queryPromise(sid, ['Vernac', command]);
   return parseZList(flattenMessages(manager, messages));
 }
 
-async function evalStepWorldWords(manager, sid, gsWords, inputSnapshot) {
+async function evalStepWorldWords(manager, sid, collisionWorldExpr, gsWords, inputSnapshot) {
   const command =
-    `Eval cbv in (step_world_words ` +
+    `Eval vm_compute in (step_world_words_in_world ${collisionWorldExpr} ` +
     `${formatZList(gsWords)} ${formatInputSnapshot(inputSnapshot)}).`;
   const messages = await manager.coq.queryPromise(sid, ['Vernac', command]);
   const words = parseZList(flattenMessages(manager, messages));
@@ -238,6 +288,7 @@ export function createRocqBridge(manager) {
   let gsWords = null;        // current game-state word list
   let initialGsWords = null; // snapshot saved at load_world for reset()
   let visibleFaces = null;   // static visible-face indices (no PVS yet)
+  let collisionWorldExpr = null;
 
   function getBridgeHelpersSid() {
     bridgeHelpersSidPromise ||= ensureBridgeHelpersReady(manager);
@@ -257,6 +308,7 @@ export function createRocqBridge(manager) {
         evalInitialGameStateWords(manager, sid, world),
         evalVisibleFaces(manager, sid, world),
       ]);
+      collisionWorldExpr = formatCollisionWorld(world);
       gsWords        = words;
       initialGsWords = [...words];
       visibleFaces   = faces;
@@ -266,7 +318,7 @@ export function createRocqBridge(manager) {
     async step(inputSnapshot) {
       assertLoaded();
       const sid = await getBridgeHelpersSid();
-      gsWords = await evalStepWorldWords(manager, sid, gsWords, inputSnapshot);
+      gsWords = await evalStepWorldWords(manager, sid, collisionWorldExpr, gsWords, inputSnapshot);
       return snapshotFromGameStateWords(gsWords, visibleFaces);
     },
 

--- a/docs/theories/BspCore.v
+++ b/docs/theories/BspCore.v
@@ -1093,3 +1093,174 @@ Proof.
   apply (visible_face_indices_aux_bounds faces textures 0 i) in Hin.
   simpl in Hin. lia.
 Qed.
+
+(* ------------------------------------------------------------------ *)
+(** ** World-state serialization and frame stepping                    *)
+(* ------------------------------------------------------------------ *)
+
+(** Number of [Z] words produced by [game_state_to_words] for a
+    game state with an empty entity list. *)
+Definition game_state_words_count : nat := 18.
+
+(** Serialize a [game_state] to a flat [list Z] suitable for
+    round-tripping through the JS bridge.  The entity list is
+    omitted; v1 entities carry no per-step dynamic state that
+    needs crossing the bridge boundary.
+
+    Word layout (18 entries):
+    <<
+       0  px_num   1  px_den
+       2  py_num   3  py_den
+       4  pz_num   5  pz_den
+       6  vx_num   7  vx_den
+       8  vy_num   9  vy_den
+      10  vz_num  11  vz_den
+      12 yaw_num  13 yaw_den
+      14 pch_num  15 pch_den
+      16 on_ground          (0 = airborne, 1 = grounded)
+      17 tick
+    >>
+*)
+Definition game_state_to_words (gs : game_state) : list Z :=
+  q_words (v3_x (gs_position gs)) ++
+  q_words (v3_y (gs_position gs)) ++
+  q_words (v3_z (gs_position gs)) ++
+  q_words (v3_x (gs_velocity gs)) ++
+  q_words (v3_y (gs_velocity gs)) ++
+  q_words (v3_z (gs_velocity gs)) ++
+  q_words (gs_yaw gs) ++
+  q_words (gs_pitch gs) ++
+  [(if gs_on_ground gs then 1 else 0)] ++
+  [gs_tick gs].
+
+(** Reconstruct a [game_state] from the word list produced by
+    [game_state_to_words].  Returns [None] on a malformed list or
+    any zero/negative denominator. *)
+Definition game_state_from_words (ws : list Z) : option game_state :=
+  match ws with
+  | [px_n; px_d; py_n; py_d; pz_n; pz_d;
+     vx_n; vx_d; vy_n; vy_d; vz_n; vz_d;
+     yaw_n; yaw_d; pitch_n; pitch_d;
+     on_ground; tick] =>
+      if (px_d <=? 0) || (py_d <=? 0) || (pz_d <=? 0) ||
+         (vx_d <=? 0) || (vy_d <=? 0) || (vz_d <=? 0) ||
+         (yaw_d <=? 0) || (pitch_d <=? 0)
+      then None
+      else
+        Some (mk_game_state
+          (mk_vec3 (Qmake px_n (Z.to_pos px_d))
+                   (Qmake py_n (Z.to_pos py_d))
+                   (Qmake pz_n (Z.to_pos pz_d)))
+          (mk_vec3 (Qmake vx_n (Z.to_pos vx_d))
+                   (Qmake vy_n (Z.to_pos vy_d))
+                   (Qmake vz_n (Z.to_pos vz_d)))
+          (Qmake yaw_n   (Z.to_pos yaw_d))
+          (Qmake pitch_n (Z.to_pos pitch_d))
+          (negb (on_ground =? 0))
+          []
+          tick)
+  | _ => None
+  end.
+
+(** Advance the world by one frame.  For this phase the only change
+    is incrementing [gs_tick]; movement, look, and collision logic
+    will be added in subsequent tasks. *)
+Definition step_world (gs : game_state) (_input : input_snapshot)
+    : game_state :=
+  mk_game_state
+    (gs_position gs)
+    (gs_velocity gs)
+    (gs_yaw gs)
+    (gs_pitch gs)
+    (gs_on_ground gs)
+    (gs_entities gs)
+    (gs_tick gs + 1).
+
+(** Bridge-facing word-level entry point for per-frame stepping.
+    Takes the current game state as a word list (from
+    [game_state_to_words]) plus the packed input snapshot, and
+    returns the updated word list.  A malformed input word list is
+    passed through unchanged. *)
+Definition step_world_words (ws : list Z) (input : input_snapshot)
+    : list Z :=
+  match game_state_from_words ws with
+  | None    => ws
+  | Some gs => game_state_to_words (step_world gs input)
+  end.
+
+(** Bridge-facing entry point for [load_world].  Returns the initial
+    game-state word list from parsed entity data.  Used alongside
+    [initial_visible_faces_from_inputs] to populate the first
+    render snapshot. *)
+Definition initial_game_state_words_from_entities
+    (entities : list bsp_entity) : list Z :=
+  game_state_to_words (game_state_from_entities entities).
+
+(* ------------------------------------------------------------------ *)
+(** ** Correctness lemmas for world stepping                           *)
+(* ------------------------------------------------------------------ *)
+
+Lemma game_state_to_words_length : forall gs,
+  length (game_state_to_words gs) = game_state_words_count.
+Proof.
+  intros gs. unfold game_state_to_words, q_words, game_state_words_count.
+  repeat rewrite length_app. simpl. reflexivity.
+Qed.
+
+(** Stepping preserves position. *)
+Lemma step_world_position : forall gs input,
+  gs_position (step_world gs input) = gs_position gs.
+Proof. reflexivity. Qed.
+
+(** Stepping preserves velocity. *)
+Lemma step_world_velocity : forall gs input,
+  gs_velocity (step_world gs input) = gs_velocity gs.
+Proof. reflexivity. Qed.
+
+(** Stepping preserves orientation. *)
+Lemma step_world_yaw : forall gs input,
+  gs_yaw (step_world gs input) = gs_yaw gs.
+Proof. reflexivity. Qed.
+
+Lemma step_world_pitch : forall gs input,
+  gs_pitch (step_world gs input) = gs_pitch gs.
+Proof. reflexivity. Qed.
+
+(** Stepping increments the tick counter. *)
+Lemma step_world_tick : forall gs input,
+  gs_tick (step_world gs input) = gs_tick gs + 1.
+Proof. reflexivity. Qed.
+
+(** Helper: [Z.pos p] is never [<=? 0]. *)
+Lemma Z_pos_leb_0 : forall p : positive,
+  (Z.pos p <=? 0) = false.
+Proof.
+  intro p. apply Z.leb_gt. apply Pos2Z.is_pos.
+Qed.
+
+(** [game_state_to_words] round-trips through [game_state_from_words]
+    for states with an empty entity list. *)
+Lemma game_state_roundtrip : forall gs,
+  gs_entities gs = [] ->
+  game_state_from_words (game_state_to_words gs) = Some gs.
+Proof.
+  intros gs Hnil.
+  destruct gs as [[px py pz] [vx vy vz] yaw pitch grounded ents tick].
+  simpl in Hnil. subst ents.
+  (* Destruct each Q into num/den so Z.to_pos (Z.pos den) = den by reflexivity. *)
+  destruct px as [pxn pxd], py as [pyn pyd], pz as [pzn pzd].
+  destruct vx as [vxn vxd], vy as [vyn vyd], vz as [vzn vzd].
+  destruct yaw as [yn yd], pitch as [pn pd].
+  unfold game_state_to_words, game_state_from_words, q_words. simpl.
+  repeat rewrite Z_pos_leb_0. simpl.
+  destruct grounded; reflexivity.
+Qed.
+
+(** Serialized word count matches [game_state_words_count]. *)
+Lemma initial_game_state_words_from_entities_length : forall entities,
+  length (initial_game_state_words_from_entities entities) =
+  game_state_words_count.
+Proof.
+  intros entities. unfold initial_game_state_words_from_entities.
+  apply game_state_to_words_length.
+Qed.

--- a/docs/theories/BspCore.v
+++ b/docs/theories/BspCore.v
@@ -1557,6 +1557,18 @@ Lemma step_pitch_clamps_high :
   step_pitch 10%Q 100%Q = pitch_limit.
 Proof. vm_compute. reflexivity. Qed.
 
+Lemma step_pitch_clamps_low :
+  step_pitch (-10)%Q (-100)%Q = (- pitch_limit)%Q.
+Proof. vm_compute. reflexivity. Qed.
+
+Lemma step_world_turn_then_move_example :
+  let pos :=
+    gs_position
+      (step_world game_state_init
+        (mk_input_snapshot true false false false false 90%Q 0%Q 1000)) in
+  v3_x pos == 0 /\ v3_y pos == 320 /\ v3_z pos == 0.
+Proof. vm_compute. repeat split; reflexivity. Qed.
+
 Lemma step_world_forward_example :
   let pos :=
     gs_position
@@ -1572,6 +1584,23 @@ Lemma step_world_right_at_ninety_example :
         (mk_game_state vec3_zero vec3_zero 90%Q 0 true [] 0)
         (mk_input_snapshot false false false true false 0%Q 0%Q 1000)) in
   v3_x pos == -320 /\ v3_y pos == 0 /\ v3_z pos == 0.
+Proof. vm_compute. repeat split; reflexivity. Qed.
+
+Lemma step_world_conflicting_axes_cancel_example :
+  let pos :=
+    gs_position
+      (step_world game_state_init
+        (mk_input_snapshot true true true true false 0%Q 0%Q 1000)) in
+  v3_x pos == 0 /\ v3_y pos == 0 /\ v3_z pos == 0.
+Proof. vm_compute. repeat split; reflexivity. Qed.
+
+Lemma step_world_zero_dt_preserves_position_example :
+  let pos :=
+    gs_position
+      (step_world
+        (mk_game_state (mk_vec3 5 6 7) vec3_zero 0 0 true [] 0)
+        (mk_input_snapshot true false false false false 0%Q 0%Q 0)) in
+  v3_x pos == 5 /\ v3_y pos == 6 /\ v3_z pos == 7.
 Proof. vm_compute. repeat split; reflexivity. Qed.
 
 (** Helper: [Z.pos p] is never [<=? 0]. *)
@@ -1659,6 +1688,16 @@ Lemma step_world_in_world_empty_applies_gravity :
       (mk_input_snapshot false false false false false 0%Q 0%Q 1000) in
   v3_z (gs_position stepped) == -800 /\ gs_on_ground stepped = false.
 Proof. vm_compute. split; reflexivity. Qed.
+
+Lemma step_world_in_world_grounded_jump_example :
+  let stepped :=
+    step_world_in_world sample_floor_world
+      (mk_game_state (mk_vec3 0 0 17) vec3_zero 0 0 false [] 0)
+      (mk_input_snapshot false false false false true 0%Q 0%Q 100) in
+  v3_z (gs_position stepped) == 44 /\
+  v3_z (gs_velocity stepped) == jump_speed /\
+  gs_on_ground stepped = false.
+Proof. vm_compute. repeat split; reflexivity. Qed.
 
 Lemma brush_blocks_playerb_sample_solid :
   brush_blocks_playerb [sample_solid_texture] (mk_collision_brush_input 0 6 0) = true.

--- a/docs/theories/BspCore.v
+++ b/docs/theories/BspCore.v
@@ -649,6 +649,38 @@ Record render_face_input : Type := mk_render_face_input
   ; rfi_size_y      : Z
   }.
 
+(** Minimal plane data needed for BSP brush collision. *)
+Record collision_plane_input : Type := mk_collision_plane_input
+  { cpi_normal_x : Q
+  ; cpi_normal_y : Q
+  ; cpi_normal_z : Q
+  ; cpi_dist     : Q
+  }.
+
+(** Minimal texture metadata needed to decide whether a brush blocks
+    the player. *)
+Record collision_texture_input : Type := mk_collision_texture_input
+  { cti_contents : Z }.
+
+(** Minimal brush data needed for BSP collision. *)
+Record collision_brush_input : Type := mk_collision_brush_input
+  { cbi_first_side    : Z
+  ; cbi_num_sides     : Z
+  ; cbi_texture_index : Z
+  }.
+
+(** Minimal brush-side data needed for BSP collision. *)
+Record collision_brush_side_input : Type := mk_collision_brush_side_input
+  { cbsi_plane_index : Z }.
+
+(** Static BSP collision data provided by the browser at world load. *)
+Record collision_world_input : Type := mk_collision_world_input
+  { cwi_planes      : list collision_plane_input
+  ; cwi_textures    : list collision_texture_input
+  ; cwi_brushes     : list collision_brush_input
+  ; cwi_brush_sides : list collision_brush_side_input
+  }.
+
 Definition face_type_polygon : Z := 1.
 Definition face_type_patch   : Z := 2.
 Definition face_type_mesh    : Z := 3.
@@ -714,6 +746,11 @@ Definition visible_face_indices
     (faces : list render_face_input)
     (textures : list render_texture_input) : list Z :=
   visible_face_indices_aux faces textures 0.
+
+Definition collision_world_empty : collision_world_input :=
+  mk_collision_world_input [] [] [] [].
+
+Definition contents_solid : Z := 1.
 
 (* ------------------------------------------------------------------ *)
 (** ** Game state (Rocq-owned, authoritative)                          *)
@@ -989,6 +1026,140 @@ Definition initial_visible_faces_from_inputs
     (initial_render_snapshot_from_inputs entities faces textures).
 
 (* ------------------------------------------------------------------ *)
+(** ** BSP collision helpers                                            *)
+(* ------------------------------------------------------------------ *)
+
+Definition qleb (a b : Q) : bool :=
+  if Qlt_le_dec b a then false else true.
+
+Definition vec3_dot (a b : vec3) : Q :=
+  (v3_x a * v3_x b + v3_y a * v3_y b + v3_z a * v3_z b)%Q.
+
+Definition vec3_midpoint (a b : vec3) : vec3 :=
+  mk_vec3
+    ((v3_x a + v3_x b) / 2)%Q
+    ((v3_y a + v3_y b) / 2)%Q
+    ((v3_z a + v3_z b) / 2)%Q.
+
+Definition plane_normal (pl : collision_plane_input) : vec3 :=
+  mk_vec3 (cpi_normal_x pl) (cpi_normal_y pl) (cpi_normal_z pl).
+
+Definition brush_blocks_playerb
+    (textures : list collision_texture_input) (br : collision_brush_input) : bool :=
+  match nth_z textures (cbi_texture_index br) with
+  | Some tx =>
+      bit_setb (cti_contents tx) contents_solid ||
+      bit_setb (cti_contents tx) contents_playerclip
+  | None => false
+  end.
+
+Definition plane_signed_distance
+    (pl : collision_plane_input) (pos : vec3) : Q :=
+  (vec3_dot (plane_normal pl) pos - cpi_dist pl)%Q.
+
+Definition player_radius : Q := 16.
+Definition ground_probe_distance : Q := 1.
+Definition gravity_accel : Q := 800.
+Definition jump_speed : Q := 270.
+Definition collision_sweep_iterations : nat := 8%nat.
+Definition collision_motion_substeps : nat := 16%nat.
+Definition collision_motion_substep_scale : Q := (1 # 16)%Q.
+
+Fixpoint point_collides_brush_aux
+    (planes : list collision_plane_input)
+    (brush_sides : list collision_brush_side_input)
+    (pos : vec3)
+    (side_index : Z)
+    (fuel : nat) : bool :=
+  match fuel with
+  | O => true
+  | S fuel' =>
+      match nth_z brush_sides side_index with
+      | None => false
+      | Some side =>
+          match nth_z planes (cbsi_plane_index side) with
+          | None => false
+          | Some plane =>
+              if qleb (plane_signed_distance plane pos) player_radius
+              then point_collides_brush_aux planes brush_sides pos (side_index + 1) fuel'
+              else false
+          end
+      end
+  end.
+
+Definition point_collides_brushb
+    (world : collision_world_input) (pos : vec3) (br : collision_brush_input) : bool :=
+  if brush_blocks_playerb (cwi_textures world) br then
+    match Z.max 0 (cbi_num_sides br) with
+    | 0 => false
+    | n =>
+        point_collides_brush_aux
+          (cwi_planes world)
+          (cwi_brush_sides world)
+          pos
+          (cbi_first_side br)
+          (Z.to_nat n)
+    end
+  else false.
+
+Fixpoint point_collides_world_aux
+    (world : collision_world_input) (pos : vec3)
+    (brushes : list collision_brush_input) : bool :=
+  match brushes with
+  | [] => false
+  | br :: rest =>
+      if point_collides_brushb world pos br then true
+      else point_collides_world_aux world pos rest
+  end.
+
+Definition point_collides_worldb
+    (world : collision_world_input) (pos : vec3) : bool :=
+  point_collides_world_aux world pos (cwi_brushes world).
+
+Fixpoint sweep_to_contact
+    (world : collision_world_input) (lo hi : vec3) (fuel : nat) : vec3 :=
+  match fuel with
+  | O => lo
+  | S fuel' =>
+      let mid := vec3_midpoint lo hi in
+      if point_collides_worldb world mid
+      then sweep_to_contact world lo mid fuel'
+      else sweep_to_contact world mid hi fuel'
+  end.
+
+Definition resolve_motion
+    (world : collision_world_input) (start delta : vec3) : vec3 * bool :=
+  let target := vec3_add start delta in
+  if point_collides_worldb world start then (start, true) else
+  if point_collides_worldb world target
+  then (sweep_to_contact world start target collision_sweep_iterations, true)
+  else (target, false).
+
+Fixpoint resolve_motion_substeps_aux
+    (world : collision_world_input) (pos step_delta : vec3) (fuel : nat)
+    : vec3 * bool :=
+  match fuel with
+  | O => (pos, false)
+  | S fuel' =>
+      let '(next_pos, blocked_now) := resolve_motion world pos step_delta in
+      if blocked_now then (next_pos, true)
+      else resolve_motion_substeps_aux world next_pos step_delta fuel'
+  end.
+
+Definition resolve_motion_substeps
+    (world : collision_world_input) (start delta : vec3) : vec3 * bool :=
+  resolve_motion_substeps_aux
+    world
+    start
+    (vec3_scale collision_motion_substep_scale delta)
+    collision_motion_substeps.
+
+Definition grounded_by_worldb
+    (world : collision_world_input) (pos : vec3) : bool :=
+  point_collides_worldb world
+    (mk_vec3 (v3_x pos) (v3_y pos) (v3_z pos - ground_probe_distance)).
+
+(* ------------------------------------------------------------------ *)
 (** ** Correctness lemmas for spawn-point selection                     *)
 (* ------------------------------------------------------------------ *)
 
@@ -1257,6 +1428,43 @@ Definition step_world (gs : game_state) (input : input_snapshot)
     (gs_entities gs)
     (gs_tick gs + 1).
 
+Definition step_world_in_world
+    (world : collision_world_input) (gs : game_state) (input : input_snapshot)
+    : game_state :=
+  let yaw := step_yaw (gs_yaw gs) (is_yaw_delta input) in
+  let pitch := step_pitch (gs_pitch gs) (is_pitch_delta input) in
+  let dt_s := millis_to_seconds (is_dt_ms input) in
+  let grounded_start :=
+    gs_on_ground gs || grounded_by_worldb world (gs_position gs) in
+  let prior_vel_z := if grounded_start then 0%Q else v3_z (gs_velocity gs) in
+  let desired_vel_z :=
+    if grounded_start && is_jump input
+    then jump_speed
+    else (prior_vel_z - gravity_accel * dt_s)%Q in
+  let desired_planar := movement_velocity yaw 0%Q input in
+  let horizontal_delta :=
+    vec3_scale dt_s (mk_vec3 (v3_x desired_planar) (v3_y desired_planar) 0) in
+  let '(horizontal_pos, horizontal_blocked) :=
+    resolve_motion_substeps world (gs_position gs) horizontal_delta in
+  let vertical_delta := mk_vec3 0 0 (dt_s * desired_vel_z)%Q in
+  let '(position, vertical_blocked) :=
+    resolve_motion_substeps world horizontal_pos vertical_delta in
+  let landed := vertical_blocked && qleb desired_vel_z 0 in
+  let on_ground := landed || grounded_by_worldb world position in
+  let velocity :=
+    mk_vec3
+      (if horizontal_blocked then 0 else v3_x desired_planar)
+      (if horizontal_blocked then 0 else v3_y desired_planar)
+      (if vertical_blocked then 0 else desired_vel_z) in
+  mk_game_state
+    position
+    velocity
+    yaw
+    pitch
+    on_ground
+    (gs_entities gs)
+    (gs_tick gs + 1).
+
 (** Bridge-facing word-level entry point for per-frame stepping.
     Takes the current game state as a word list (from
     [game_state_to_words]) plus the packed input snapshot, and
@@ -1267,6 +1475,14 @@ Definition step_world_words (ws : list Z) (input : input_snapshot)
   match game_state_from_words ws with
   | None    => ws
   | Some gs => game_state_to_words (step_world gs input)
+  end.
+
+Definition step_world_words_in_world
+    (world : collision_world_input)
+    (ws : list Z) (input : input_snapshot) : list Z :=
+  match game_state_from_words ws with
+  | None    => ws
+  | Some gs => game_state_to_words (step_world_in_world world gs input)
   end.
 
 (** Bridge-facing entry point for [load_world].  Returns the initial
@@ -1391,3 +1607,71 @@ Proof.
   intros entities. unfold initial_game_state_words_from_entities.
   apply game_state_to_words_length.
 Qed.
+
+Lemma point_collides_worldb_empty : forall pos,
+  point_collides_worldb collision_world_empty pos = false.
+Proof. reflexivity. Qed.
+
+Definition sample_solid_texture : collision_texture_input :=
+  mk_collision_texture_input contents_solid.
+
+Definition sample_floor_world : collision_world_input :=
+  mk_collision_world_input
+    [ mk_collision_plane_input   1    0    0 1024
+    ; mk_collision_plane_input (-1)   0    0 1024
+    ; mk_collision_plane_input   0    1    0 1024
+    ; mk_collision_plane_input   0  (-1)   0 1024
+    ; mk_collision_plane_input   0    0    1    0
+    ; mk_collision_plane_input   0    0  (-1)  64
+    ]
+    [sample_solid_texture]
+    [mk_collision_brush_input 0 6 0]
+    [ mk_collision_brush_side_input 0
+    ; mk_collision_brush_side_input 1
+    ; mk_collision_brush_side_input 2
+    ; mk_collision_brush_side_input 3
+    ; mk_collision_brush_side_input 4
+    ; mk_collision_brush_side_input 5
+    ].
+
+Definition sample_wall_world : collision_world_input :=
+  mk_collision_world_input
+    [ mk_collision_plane_input   1    0    0   96
+    ; mk_collision_plane_input (-1)   0    0  (-32)
+    ; mk_collision_plane_input   0    1    0 1024
+    ; mk_collision_plane_input   0  (-1)   0 1024
+    ; mk_collision_plane_input   0    0    1 1024
+    ; mk_collision_plane_input   0    0  (-1) 1024
+    ]
+    [sample_solid_texture]
+    [mk_collision_brush_input 0 6 0]
+    [ mk_collision_brush_side_input 0
+    ; mk_collision_brush_side_input 1
+    ; mk_collision_brush_side_input 2
+    ; mk_collision_brush_side_input 3
+    ; mk_collision_brush_side_input 4
+    ; mk_collision_brush_side_input 5
+    ].
+
+Lemma step_world_in_world_empty_applies_gravity :
+  let stepped :=
+    step_world_in_world collision_world_empty game_state_init
+      (mk_input_snapshot false false false false false 0%Q 0%Q 1000) in
+  v3_z (gs_position stepped) == -800 /\ gs_on_ground stepped = false.
+Proof. vm_compute. split; reflexivity. Qed.
+
+Lemma brush_blocks_playerb_sample_solid :
+  brush_blocks_playerb [sample_solid_texture] (mk_collision_brush_input 0 6 0) = true.
+Proof. vm_compute. reflexivity. Qed.
+
+Lemma point_collides_worldb_sample_floor_contact :
+  point_collides_worldb sample_floor_world (mk_vec3 0 0 16) = true.
+Proof. vm_compute. reflexivity. Qed.
+
+Lemma grounded_by_worldb_sample_floor :
+  grounded_by_worldb sample_floor_world (mk_vec3 0 0 17) = true.
+Proof. vm_compute. reflexivity. Qed.
+
+Lemma point_collides_worldb_sample_wall :
+  point_collides_worldb sample_wall_world (mk_vec3 16 0 128) = true.
+Proof. vm_compute. reflexivity. Qed.

--- a/docs/theories/BspCore.v
+++ b/docs/theories/BspCore.v
@@ -576,6 +576,20 @@ Record vec3 : Type := mk_vec3
 (** The zero vector. *)
 Definition vec3_zero : vec3 := mk_vec3 0 0 0.
 
+(** Vector addition. *)
+Definition vec3_add (a b : vec3) : vec3 :=
+  mk_vec3
+    (v3_x a + v3_x b)
+    (v3_y a + v3_y b)
+    (v3_z a + v3_z b).
+
+(** Scalar multiplication of a vector. *)
+Definition vec3_scale (k : Q) (v : vec3) : vec3 :=
+  mk_vec3
+    (k * v3_x v)
+    (k * v3_y v)
+    (k * v3_z v).
+
 (* ------------------------------------------------------------------ *)
 (** ** Input snapshot (JS -> Rocq, per tick)                            *)
 (* ------------------------------------------------------------------ *)
@@ -1162,16 +1176,83 @@ Definition game_state_from_words (ws : list Z) : option game_state :=
   | _ => None
   end.
 
-(** Advance the world by one frame.  For this phase the only change
-    is incrementing [gs_tick]; movement, look, and collision logic
-    will be added in subsequent tasks. *)
-Definition step_world (gs : game_state) (_input : input_snapshot)
+(** Movement/look constants for free movement stepping. *)
+Definition yaw_full_turn : Q := 360.
+Definition pitch_limit : Q := 89.
+Definition move_speed : Q := 320.
+Definition pi_approx : Q := (355 # 113)%Q.
+
+(** Convert elapsed milliseconds to seconds as a rational. *)
+Definition millis_to_seconds (dt_ms : Z) : Q :=
+  (inject_Z dt_ms * (1 # 1000))%Q.
+
+(** Wrap a degree angle into the half-open interval [0, 360). *)
+Definition normalize_degrees_360 (angle : Q) : Q :=
+  Qmake
+    (Z.modulo (Qnum angle) (360 * Z.pos (Qden angle)))
+    (Qden angle).
+
+(** Clamp pitch so the camera never flips upside-down. *)
+Definition clamp_pitch (pitch : Q) : Q :=
+  if Qlt_le_dec pitch (- pitch_limit) then - pitch_limit else
+  if Qlt_le_dec pitch_limit pitch then pitch_limit else
+  pitch.
+
+Definition bool_to_Z (b : bool) : Z :=
+  if b then 1 else 0.
+
+Definition input_axis (positive negative : bool) : Z :=
+  bool_to_Z positive - bool_to_Z negative.
+
+(** Bhaskara I's sine approximation gives smooth rational movement
+    directions without requiring transcendental functions in Rocq. *)
+Definition bhaskara_sine_0_180 (deg : Q) : Q :=
+  let x := (deg * pi_approx / 180)%Q in
+  let prod := (x * (pi_approx - x))%Q in
+  ((16 * prod) / (5 * pi_approx * pi_approx - 4 * prod))%Q.
+
+Definition approx_sin_degrees (angle : Q) : Q :=
+  let wrapped := normalize_degrees_360 angle in
+  if Qlt_le_dec wrapped 180
+  then bhaskara_sine_0_180 wrapped
+  else (- bhaskara_sine_0_180 (wrapped - 180))%Q.
+
+Definition approx_cos_degrees (angle : Q) : Q :=
+  approx_sin_degrees (angle + 90)%Q.
+
+Definition step_yaw (yaw yaw_delta : Q) : Q :=
+  normalize_degrees_360 (yaw + yaw_delta)%Q.
+
+Definition step_pitch (pitch pitch_delta : Q) : Q :=
+  clamp_pitch (pitch + pitch_delta)%Q.
+
+Definition movement_velocity (yaw vel_z : Q) (input : input_snapshot) : vec3 :=
+  let forward_axis := inject_Z (input_axis (is_forward input) (is_back input)) in
+  let strafe_axis := inject_Z (input_axis (is_right input) (is_left input)) in
+  let cos_yaw := approx_cos_degrees yaw in
+  let sin_yaw := approx_sin_degrees yaw in
+  mk_vec3
+    (move_speed * (forward_axis * cos_yaw - strafe_axis * sin_yaw))%Q
+    (move_speed * (forward_axis * sin_yaw + strafe_axis * cos_yaw))%Q
+    vel_z.
+
+Definition advance_position (pos velocity : vec3) (dt_ms : Z) : vec3 :=
+  vec3_add pos (vec3_scale (millis_to_seconds dt_ms) velocity).
+
+(** Advance the world by one frame: apply look deltas, derive planar
+    movement from the updated yaw, and integrate position using the
+    per-tick delta time. *)
+Definition step_world (gs : game_state) (input : input_snapshot)
     : game_state :=
+  let yaw := step_yaw (gs_yaw gs) (is_yaw_delta input) in
+  let pitch := step_pitch (gs_pitch gs) (is_pitch_delta input) in
+  let velocity := movement_velocity yaw (v3_z (gs_velocity gs)) input in
+  let position := advance_position (gs_position gs) velocity (is_dt_ms input) in
   mk_game_state
-    (gs_position gs)
-    (gs_velocity gs)
-    (gs_yaw gs)
-    (gs_pitch gs)
+    position
+    velocity
+    yaw
+    pitch
     (gs_on_ground gs)
     (gs_entities gs)
     (gs_tick gs + 1).
@@ -1207,29 +1288,75 @@ Proof.
   repeat rewrite length_app. simpl. reflexivity.
 Qed.
 
-(** Stepping preserves position. *)
+(** Stepping integrates position from the per-frame velocity. *)
 Lemma step_world_position : forall gs input,
-  gs_position (step_world gs input) = gs_position gs.
+  gs_position (step_world gs input) =
+  advance_position
+    (gs_position gs)
+    (movement_velocity
+       (step_yaw (gs_yaw gs) (is_yaw_delta input))
+       (v3_z (gs_velocity gs))
+       input)
+    (is_dt_ms input).
 Proof. reflexivity. Qed.
 
-(** Stepping preserves velocity. *)
+(** Stepping derives movement velocity from the updated yaw. *)
 Lemma step_world_velocity : forall gs input,
-  gs_velocity (step_world gs input) = gs_velocity gs.
+  gs_velocity (step_world gs input) =
+  movement_velocity
+    (step_yaw (gs_yaw gs) (is_yaw_delta input))
+    (v3_z (gs_velocity gs))
+    input.
 Proof. reflexivity. Qed.
 
-(** Stepping preserves orientation. *)
+(** Stepping applies look input to orientation. *)
 Lemma step_world_yaw : forall gs input,
-  gs_yaw (step_world gs input) = gs_yaw gs.
+  gs_yaw (step_world gs input) =
+  step_yaw (gs_yaw gs) (is_yaw_delta input).
 Proof. reflexivity. Qed.
 
 Lemma step_world_pitch : forall gs input,
-  gs_pitch (step_world gs input) = gs_pitch gs.
+  gs_pitch (step_world gs input) =
+  step_pitch (gs_pitch gs) (is_pitch_delta input).
+Proof. reflexivity. Qed.
+
+Lemma step_world_on_ground : forall gs input,
+  gs_on_ground (step_world gs input) = gs_on_ground gs.
+Proof. reflexivity. Qed.
+
+Lemma step_world_entities : forall gs input,
+  gs_entities (step_world gs input) = gs_entities gs.
 Proof. reflexivity. Qed.
 
 (** Stepping increments the tick counter. *)
 Lemma step_world_tick : forall gs input,
   gs_tick (step_world gs input) = gs_tick gs + 1.
 Proof. reflexivity. Qed.
+
+Lemma normalize_degrees_360_wraps_negative :
+  normalize_degrees_360 (-10)%Q = 350%Q.
+Proof. vm_compute. reflexivity. Qed.
+
+Lemma step_pitch_clamps_high :
+  step_pitch 10%Q 100%Q = pitch_limit.
+Proof. vm_compute. reflexivity. Qed.
+
+Lemma step_world_forward_example :
+  let pos :=
+    gs_position
+      (step_world game_state_init
+        (mk_input_snapshot true false false false false 0%Q 0%Q 1000)) in
+  v3_x pos == 320 /\ v3_y pos == 0 /\ v3_z pos == 0.
+Proof. vm_compute. repeat split; reflexivity. Qed.
+
+Lemma step_world_right_at_ninety_example :
+  let pos :=
+    gs_position
+      (step_world
+        (mk_game_state vec3_zero vec3_zero 90%Q 0 true [] 0)
+        (mk_input_snapshot false false false true false 0%Q 0%Q 1000)) in
+  v3_x pos == -320 /\ v3_y pos == 0 /\ v3_z pos == 0.
+Proof. vm_compute. repeat split; reflexivity. Qed.
 
 (** Helper: [Z.pos p] is never [<=? 0]. *)
 Lemma Z_pos_leb_0 : forall p : positive,

--- a/theories/GameState.v
+++ b/theories/GameState.v
@@ -46,6 +46,20 @@ Record vec3 : Type := mk_vec3
 (** The zero vector. *)
 Definition vec3_zero : vec3 := mk_vec3 0 0 0.
 
+(** Vector addition. *)
+Definition vec3_add (a b : vec3) : vec3 :=
+  mk_vec3
+    (v3_x a + v3_x b)
+    (v3_y a + v3_y b)
+    (v3_z a + v3_z b).
+
+(** Scalar multiplication of a vector. *)
+Definition vec3_scale (k : Q) (v : vec3) : vec3 :=
+  mk_vec3
+    (k * v3_x v)
+    (k * v3_y v)
+    (k * v3_z v).
+
 (* ------------------------------------------------------------------ *)
 (** ** Input snapshot (JS -> Rocq, per tick)                            *)
 (* ------------------------------------------------------------------ *)
@@ -632,16 +646,83 @@ Definition game_state_from_words (ws : list Z) : option game_state :=
   | _ => None
   end.
 
-(** Advance the world by one frame.  For this phase the only change
-    is incrementing [gs_tick]; movement, look, and collision logic
-    will be added in subsequent tasks. *)
-Definition step_world (gs : game_state) (_input : input_snapshot)
+(** Movement/look constants for free movement stepping. *)
+Definition yaw_full_turn : Q := 360.
+Definition pitch_limit : Q := 89.
+Definition move_speed : Q := 320.
+Definition pi_approx : Q := (355 # 113)%Q.
+
+(** Convert elapsed milliseconds to seconds as a rational. *)
+Definition millis_to_seconds (dt_ms : Z) : Q :=
+  (inject_Z dt_ms * (1 # 1000))%Q.
+
+(** Wrap a degree angle into the half-open interval [0, 360). *)
+Definition normalize_degrees_360 (angle : Q) : Q :=
+  Qmake
+    (Z.modulo (Qnum angle) (360 * Z.pos (Qden angle)))
+    (Qden angle).
+
+(** Clamp pitch so the camera never flips upside-down. *)
+Definition clamp_pitch (pitch : Q) : Q :=
+  if Qlt_le_dec pitch (- pitch_limit) then - pitch_limit else
+  if Qlt_le_dec pitch_limit pitch then pitch_limit else
+  pitch.
+
+Definition bool_to_Z (b : bool) : Z :=
+  if b then 1 else 0.
+
+Definition input_axis (positive negative : bool) : Z :=
+  bool_to_Z positive - bool_to_Z negative.
+
+(** Bhaskara I's sine approximation gives smooth rational movement
+    directions without requiring transcendental functions in Rocq. *)
+Definition bhaskara_sine_0_180 (deg : Q) : Q :=
+  let x := (deg * pi_approx / 180)%Q in
+  let prod := (x * (pi_approx - x))%Q in
+  ((16 * prod) / (5 * pi_approx * pi_approx - 4 * prod))%Q.
+
+Definition approx_sin_degrees (angle : Q) : Q :=
+  let wrapped := normalize_degrees_360 angle in
+  if Qlt_le_dec wrapped 180
+  then bhaskara_sine_0_180 wrapped
+  else (- bhaskara_sine_0_180 (wrapped - 180))%Q.
+
+Definition approx_cos_degrees (angle : Q) : Q :=
+  approx_sin_degrees (angle + 90)%Q.
+
+Definition step_yaw (yaw yaw_delta : Q) : Q :=
+  normalize_degrees_360 (yaw + yaw_delta)%Q.
+
+Definition step_pitch (pitch pitch_delta : Q) : Q :=
+  clamp_pitch (pitch + pitch_delta)%Q.
+
+Definition movement_velocity (yaw vel_z : Q) (input : input_snapshot) : vec3 :=
+  let forward_axis := inject_Z (input_axis (is_forward input) (is_back input)) in
+  let strafe_axis := inject_Z (input_axis (is_right input) (is_left input)) in
+  let cos_yaw := approx_cos_degrees yaw in
+  let sin_yaw := approx_sin_degrees yaw in
+  mk_vec3
+    (move_speed * (forward_axis * cos_yaw - strafe_axis * sin_yaw))%Q
+    (move_speed * (forward_axis * sin_yaw + strafe_axis * cos_yaw))%Q
+    vel_z.
+
+Definition advance_position (pos velocity : vec3) (dt_ms : Z) : vec3 :=
+  vec3_add pos (vec3_scale (millis_to_seconds dt_ms) velocity).
+
+(** Advance the world by one frame: apply look deltas, derive planar
+    movement from the updated yaw, and integrate position using the
+    per-tick delta time. *)
+Definition step_world (gs : game_state) (input : input_snapshot)
     : game_state :=
+  let yaw := step_yaw (gs_yaw gs) (is_yaw_delta input) in
+  let pitch := step_pitch (gs_pitch gs) (is_pitch_delta input) in
+  let velocity := movement_velocity yaw (v3_z (gs_velocity gs)) input in
+  let position := advance_position (gs_position gs) velocity (is_dt_ms input) in
   mk_game_state
-    (gs_position gs)
-    (gs_velocity gs)
-    (gs_yaw gs)
-    (gs_pitch gs)
+    position
+    velocity
+    yaw
+    pitch
     (gs_on_ground gs)
     (gs_entities gs)
     (gs_tick gs + 1).
@@ -677,29 +758,75 @@ Proof.
   repeat rewrite length_app. simpl. reflexivity.
 Qed.
 
-(** Stepping preserves position. *)
+(** Stepping integrates position from the per-frame velocity. *)
 Lemma step_world_position : forall gs input,
-  gs_position (step_world gs input) = gs_position gs.
+  gs_position (step_world gs input) =
+  advance_position
+    (gs_position gs)
+    (movement_velocity
+       (step_yaw (gs_yaw gs) (is_yaw_delta input))
+       (v3_z (gs_velocity gs))
+       input)
+    (is_dt_ms input).
 Proof. reflexivity. Qed.
 
-(** Stepping preserves velocity. *)
+(** Stepping derives movement velocity from the updated yaw. *)
 Lemma step_world_velocity : forall gs input,
-  gs_velocity (step_world gs input) = gs_velocity gs.
+  gs_velocity (step_world gs input) =
+  movement_velocity
+    (step_yaw (gs_yaw gs) (is_yaw_delta input))
+    (v3_z (gs_velocity gs))
+    input.
 Proof. reflexivity. Qed.
 
-(** Stepping preserves orientation. *)
+(** Stepping applies look input to orientation. *)
 Lemma step_world_yaw : forall gs input,
-  gs_yaw (step_world gs input) = gs_yaw gs.
+  gs_yaw (step_world gs input) =
+  step_yaw (gs_yaw gs) (is_yaw_delta input).
 Proof. reflexivity. Qed.
 
 Lemma step_world_pitch : forall gs input,
-  gs_pitch (step_world gs input) = gs_pitch gs.
+  gs_pitch (step_world gs input) =
+  step_pitch (gs_pitch gs) (is_pitch_delta input).
+Proof. reflexivity. Qed.
+
+Lemma step_world_on_ground : forall gs input,
+  gs_on_ground (step_world gs input) = gs_on_ground gs.
+Proof. reflexivity. Qed.
+
+Lemma step_world_entities : forall gs input,
+  gs_entities (step_world gs input) = gs_entities gs.
 Proof. reflexivity. Qed.
 
 (** Stepping increments the tick counter. *)
 Lemma step_world_tick : forall gs input,
   gs_tick (step_world gs input) = gs_tick gs + 1.
 Proof. reflexivity. Qed.
+
+Lemma normalize_degrees_360_wraps_negative :
+  normalize_degrees_360 (-10)%Q = 350%Q.
+Proof. vm_compute. reflexivity. Qed.
+
+Lemma step_pitch_clamps_high :
+  step_pitch 10%Q 100%Q = pitch_limit.
+Proof. vm_compute. reflexivity. Qed.
+
+Lemma step_world_forward_example :
+  let pos :=
+    gs_position
+      (step_world game_state_init
+        (mk_input_snapshot true false false false false 0%Q 0%Q 1000)) in
+  v3_x pos == 320 /\ v3_y pos == 0 /\ v3_z pos == 0.
+Proof. vm_compute. repeat split; reflexivity. Qed.
+
+Lemma step_world_right_at_ninety_example :
+  let pos :=
+    gs_position
+      (step_world
+        (mk_game_state vec3_zero vec3_zero 90%Q 0 true [] 0)
+        (mk_input_snapshot false false false true false 0%Q 0%Q 1000)) in
+  v3_x pos == -320 /\ v3_y pos == 0 /\ v3_z pos == 0.
+Proof. vm_compute. repeat split; reflexivity. Qed.
 
 (** Helper: [Z.pos p] is never [<=? 0]. *)
 Lemma Z_pos_leb_0 : forall p : positive,

--- a/theories/GameState.v
+++ b/theories/GameState.v
@@ -119,6 +119,38 @@ Record render_face_input : Type := mk_render_face_input
   ; rfi_size_y      : Z
   }.
 
+(** Minimal plane data needed for BSP brush collision. *)
+Record collision_plane_input : Type := mk_collision_plane_input
+  { cpi_normal_x : Q
+  ; cpi_normal_y : Q
+  ; cpi_normal_z : Q
+  ; cpi_dist     : Q
+  }.
+
+(** Minimal texture metadata needed to decide whether a brush blocks
+    the player. *)
+Record collision_texture_input : Type := mk_collision_texture_input
+  { cti_contents : Z }.
+
+(** Minimal brush data needed for BSP collision. *)
+Record collision_brush_input : Type := mk_collision_brush_input
+  { cbi_first_side    : Z
+  ; cbi_num_sides     : Z
+  ; cbi_texture_index : Z
+  }.
+
+(** Minimal brush-side data needed for BSP collision. *)
+Record collision_brush_side_input : Type := mk_collision_brush_side_input
+  { cbsi_plane_index : Z }.
+
+(** Static BSP collision data provided by the browser at world load. *)
+Record collision_world_input : Type := mk_collision_world_input
+  { cwi_planes      : list collision_plane_input
+  ; cwi_textures    : list collision_texture_input
+  ; cwi_brushes     : list collision_brush_input
+  ; cwi_brush_sides : list collision_brush_side_input
+  }.
+
 Definition face_type_polygon : Z := 1.
 Definition face_type_patch   : Z := 2.
 Definition face_type_mesh    : Z := 3.
@@ -184,6 +216,11 @@ Definition visible_face_indices
     (faces : list render_face_input)
     (textures : list render_texture_input) : list Z :=
   visible_face_indices_aux faces textures 0.
+
+Definition collision_world_empty : collision_world_input :=
+  mk_collision_world_input [] [] [] [].
+
+Definition contents_solid : Z := 1.
 
 (* ------------------------------------------------------------------ *)
 (** ** Game state (Rocq-owned, authoritative)                          *)
@@ -459,6 +496,140 @@ Definition initial_visible_faces_from_inputs
     (initial_render_snapshot_from_inputs entities faces textures).
 
 (* ------------------------------------------------------------------ *)
+(** ** BSP collision helpers                                            *)
+(* ------------------------------------------------------------------ *)
+
+Definition qleb (a b : Q) : bool :=
+  if Qlt_le_dec b a then false else true.
+
+Definition vec3_dot (a b : vec3) : Q :=
+  (v3_x a * v3_x b + v3_y a * v3_y b + v3_z a * v3_z b)%Q.
+
+Definition vec3_midpoint (a b : vec3) : vec3 :=
+  mk_vec3
+    ((v3_x a + v3_x b) / 2)%Q
+    ((v3_y a + v3_y b) / 2)%Q
+    ((v3_z a + v3_z b) / 2)%Q.
+
+Definition plane_normal (pl : collision_plane_input) : vec3 :=
+  mk_vec3 (cpi_normal_x pl) (cpi_normal_y pl) (cpi_normal_z pl).
+
+Definition brush_blocks_playerb
+    (textures : list collision_texture_input) (br : collision_brush_input) : bool :=
+  match nth_z textures (cbi_texture_index br) with
+  | Some tx =>
+      bit_setb (cti_contents tx) contents_solid ||
+      bit_setb (cti_contents tx) contents_playerclip
+  | None => false
+  end.
+
+Definition plane_signed_distance
+    (pl : collision_plane_input) (pos : vec3) : Q :=
+  (vec3_dot (plane_normal pl) pos - cpi_dist pl)%Q.
+
+Definition player_radius : Q := 16.
+Definition ground_probe_distance : Q := 1.
+Definition gravity_accel : Q := 800.
+Definition jump_speed : Q := 270.
+Definition collision_sweep_iterations : nat := 8%nat.
+Definition collision_motion_substeps : nat := 16%nat.
+Definition collision_motion_substep_scale : Q := (1 # 16)%Q.
+
+Fixpoint point_collides_brush_aux
+    (planes : list collision_plane_input)
+    (brush_sides : list collision_brush_side_input)
+    (pos : vec3)
+    (side_index : Z)
+    (fuel : nat) : bool :=
+  match fuel with
+  | O => true
+  | S fuel' =>
+      match nth_z brush_sides side_index with
+      | None => false
+      | Some side =>
+          match nth_z planes (cbsi_plane_index side) with
+          | None => false
+          | Some plane =>
+              if qleb (plane_signed_distance plane pos) player_radius
+              then point_collides_brush_aux planes brush_sides pos (side_index + 1) fuel'
+              else false
+          end
+      end
+  end.
+
+Definition point_collides_brushb
+    (world : collision_world_input) (pos : vec3) (br : collision_brush_input) : bool :=
+  if brush_blocks_playerb (cwi_textures world) br then
+    match Z.max 0 (cbi_num_sides br) with
+    | 0 => false
+    | n =>
+        point_collides_brush_aux
+          (cwi_planes world)
+          (cwi_brush_sides world)
+          pos
+          (cbi_first_side br)
+          (Z.to_nat n)
+    end
+  else false.
+
+Fixpoint point_collides_world_aux
+    (world : collision_world_input) (pos : vec3)
+    (brushes : list collision_brush_input) : bool :=
+  match brushes with
+  | [] => false
+  | br :: rest =>
+      if point_collides_brushb world pos br then true
+      else point_collides_world_aux world pos rest
+  end.
+
+Definition point_collides_worldb
+    (world : collision_world_input) (pos : vec3) : bool :=
+  point_collides_world_aux world pos (cwi_brushes world).
+
+Fixpoint sweep_to_contact
+    (world : collision_world_input) (lo hi : vec3) (fuel : nat) : vec3 :=
+  match fuel with
+  | O => lo
+  | S fuel' =>
+      let mid := vec3_midpoint lo hi in
+      if point_collides_worldb world mid
+      then sweep_to_contact world lo mid fuel'
+      else sweep_to_contact world mid hi fuel'
+  end.
+
+Definition resolve_motion
+    (world : collision_world_input) (start delta : vec3) : vec3 * bool :=
+  let target := vec3_add start delta in
+  if point_collides_worldb world start then (start, true) else
+  if point_collides_worldb world target
+  then (sweep_to_contact world start target collision_sweep_iterations, true)
+  else (target, false).
+
+Fixpoint resolve_motion_substeps_aux
+    (world : collision_world_input) (pos step_delta : vec3) (fuel : nat)
+    : vec3 * bool :=
+  match fuel with
+  | O => (pos, false)
+  | S fuel' =>
+      let '(next_pos, blocked_now) := resolve_motion world pos step_delta in
+      if blocked_now then (next_pos, true)
+      else resolve_motion_substeps_aux world next_pos step_delta fuel'
+  end.
+
+Definition resolve_motion_substeps
+    (world : collision_world_input) (start delta : vec3) : vec3 * bool :=
+  resolve_motion_substeps_aux
+    world
+    start
+    (vec3_scale collision_motion_substep_scale delta)
+    collision_motion_substeps.
+
+Definition grounded_by_worldb
+    (world : collision_world_input) (pos : vec3) : bool :=
+  point_collides_worldb world
+    (mk_vec3 (v3_x pos) (v3_y pos) (v3_z pos - ground_probe_distance)).
+
+(* ------------------------------------------------------------------ *)
 (** ** Correctness lemmas for spawn-point selection                     *)
 (* ------------------------------------------------------------------ *)
 
@@ -727,6 +898,43 @@ Definition step_world (gs : game_state) (input : input_snapshot)
     (gs_entities gs)
     (gs_tick gs + 1).
 
+Definition step_world_in_world
+    (world : collision_world_input) (gs : game_state) (input : input_snapshot)
+    : game_state :=
+  let yaw := step_yaw (gs_yaw gs) (is_yaw_delta input) in
+  let pitch := step_pitch (gs_pitch gs) (is_pitch_delta input) in
+  let dt_s := millis_to_seconds (is_dt_ms input) in
+  let grounded_start :=
+    gs_on_ground gs || grounded_by_worldb world (gs_position gs) in
+  let prior_vel_z := if grounded_start then 0%Q else v3_z (gs_velocity gs) in
+  let desired_vel_z :=
+    if grounded_start && is_jump input
+    then jump_speed
+    else (prior_vel_z - gravity_accel * dt_s)%Q in
+  let desired_planar := movement_velocity yaw 0%Q input in
+  let horizontal_delta :=
+    vec3_scale dt_s (mk_vec3 (v3_x desired_planar) (v3_y desired_planar) 0) in
+  let '(horizontal_pos, horizontal_blocked) :=
+    resolve_motion_substeps world (gs_position gs) horizontal_delta in
+  let vertical_delta := mk_vec3 0 0 (dt_s * desired_vel_z)%Q in
+  let '(position, vertical_blocked) :=
+    resolve_motion_substeps world horizontal_pos vertical_delta in
+  let landed := vertical_blocked && qleb desired_vel_z 0 in
+  let on_ground := landed || grounded_by_worldb world position in
+  let velocity :=
+    mk_vec3
+      (if horizontal_blocked then 0 else v3_x desired_planar)
+      (if horizontal_blocked then 0 else v3_y desired_planar)
+      (if vertical_blocked then 0 else desired_vel_z) in
+  mk_game_state
+    position
+    velocity
+    yaw
+    pitch
+    on_ground
+    (gs_entities gs)
+    (gs_tick gs + 1).
+
 (** Bridge-facing word-level entry point for per-frame stepping.
     Takes the current game state as a word list (from
     [game_state_to_words]) plus the packed input snapshot, and
@@ -737,6 +945,14 @@ Definition step_world_words (ws : list Z) (input : input_snapshot)
   match game_state_from_words ws with
   | None    => ws
   | Some gs => game_state_to_words (step_world gs input)
+  end.
+
+Definition step_world_words_in_world
+    (world : collision_world_input)
+    (ws : list Z) (input : input_snapshot) : list Z :=
+  match game_state_from_words ws with
+  | None    => ws
+  | Some gs => game_state_to_words (step_world_in_world world gs input)
   end.
 
 (** Bridge-facing entry point for [load_world].  Returns the initial
@@ -861,3 +1077,71 @@ Proof.
   intros entities. unfold initial_game_state_words_from_entities.
   apply game_state_to_words_length.
 Qed.
+
+Lemma point_collides_worldb_empty : forall pos,
+  point_collides_worldb collision_world_empty pos = false.
+Proof. reflexivity. Qed.
+
+Definition sample_solid_texture : collision_texture_input :=
+  mk_collision_texture_input contents_solid.
+
+Definition sample_floor_world : collision_world_input :=
+  mk_collision_world_input
+    [ mk_collision_plane_input   1    0    0 1024
+    ; mk_collision_plane_input (-1)   0    0 1024
+    ; mk_collision_plane_input   0    1    0 1024
+    ; mk_collision_plane_input   0  (-1)   0 1024
+    ; mk_collision_plane_input   0    0    1    0
+    ; mk_collision_plane_input   0    0  (-1)  64
+    ]
+    [sample_solid_texture]
+    [mk_collision_brush_input 0 6 0]
+    [ mk_collision_brush_side_input 0
+    ; mk_collision_brush_side_input 1
+    ; mk_collision_brush_side_input 2
+    ; mk_collision_brush_side_input 3
+    ; mk_collision_brush_side_input 4
+    ; mk_collision_brush_side_input 5
+    ].
+
+Definition sample_wall_world : collision_world_input :=
+  mk_collision_world_input
+    [ mk_collision_plane_input   1    0    0   96
+    ; mk_collision_plane_input (-1)   0    0  (-32)
+    ; mk_collision_plane_input   0    1    0 1024
+    ; mk_collision_plane_input   0  (-1)   0 1024
+    ; mk_collision_plane_input   0    0    1 1024
+    ; mk_collision_plane_input   0    0  (-1) 1024
+    ]
+    [sample_solid_texture]
+    [mk_collision_brush_input 0 6 0]
+    [ mk_collision_brush_side_input 0
+    ; mk_collision_brush_side_input 1
+    ; mk_collision_brush_side_input 2
+    ; mk_collision_brush_side_input 3
+    ; mk_collision_brush_side_input 4
+    ; mk_collision_brush_side_input 5
+    ].
+
+Lemma step_world_in_world_empty_applies_gravity :
+  let stepped :=
+    step_world_in_world collision_world_empty game_state_init
+      (mk_input_snapshot false false false false false 0%Q 0%Q 1000) in
+  v3_z (gs_position stepped) == -800 /\ gs_on_ground stepped = false.
+Proof. vm_compute. split; reflexivity. Qed.
+
+Lemma brush_blocks_playerb_sample_solid :
+  brush_blocks_playerb [sample_solid_texture] (mk_collision_brush_input 0 6 0) = true.
+Proof. vm_compute. reflexivity. Qed.
+
+Lemma point_collides_worldb_sample_floor_contact :
+  point_collides_worldb sample_floor_world (mk_vec3 0 0 16) = true.
+Proof. vm_compute. reflexivity. Qed.
+
+Lemma grounded_by_worldb_sample_floor :
+  grounded_by_worldb sample_floor_world (mk_vec3 0 0 17) = true.
+Proof. vm_compute. reflexivity. Qed.
+
+Lemma point_collides_worldb_sample_wall :
+  point_collides_worldb sample_wall_world (mk_vec3 16 0 128) = true.
+Proof. vm_compute. reflexivity. Qed.

--- a/theories/GameState.v
+++ b/theories/GameState.v
@@ -563,3 +563,174 @@ Proof.
   apply (visible_face_indices_aux_bounds faces textures 0 i) in Hin.
   simpl in Hin. lia.
 Qed.
+
+(* ------------------------------------------------------------------ *)
+(** ** World-state serialization and frame stepping                    *)
+(* ------------------------------------------------------------------ *)
+
+(** Number of [Z] words produced by [game_state_to_words] for a
+    game state with an empty entity list. *)
+Definition game_state_words_count : nat := 18.
+
+(** Serialize a [game_state] to a flat [list Z] suitable for
+    round-tripping through the JS bridge.  The entity list is
+    omitted; v1 entities carry no per-step dynamic state that
+    needs crossing the bridge boundary.
+
+    Word layout (18 entries):
+    <<
+       0  px_num   1  px_den
+       2  py_num   3  py_den
+       4  pz_num   5  pz_den
+       6  vx_num   7  vx_den
+       8  vy_num   9  vy_den
+      10  vz_num  11  vz_den
+      12 yaw_num  13 yaw_den
+      14 pch_num  15 pch_den
+      16 on_ground          (0 = airborne, 1 = grounded)
+      17 tick
+    >>
+*)
+Definition game_state_to_words (gs : game_state) : list Z :=
+  q_words (v3_x (gs_position gs)) ++
+  q_words (v3_y (gs_position gs)) ++
+  q_words (v3_z (gs_position gs)) ++
+  q_words (v3_x (gs_velocity gs)) ++
+  q_words (v3_y (gs_velocity gs)) ++
+  q_words (v3_z (gs_velocity gs)) ++
+  q_words (gs_yaw gs) ++
+  q_words (gs_pitch gs) ++
+  [(if gs_on_ground gs then 1 else 0)] ++
+  [gs_tick gs].
+
+(** Reconstruct a [game_state] from the word list produced by
+    [game_state_to_words].  Returns [None] on a malformed list or
+    any zero/negative denominator. *)
+Definition game_state_from_words (ws : list Z) : option game_state :=
+  match ws with
+  | [px_n; px_d; py_n; py_d; pz_n; pz_d;
+     vx_n; vx_d; vy_n; vy_d; vz_n; vz_d;
+     yaw_n; yaw_d; pitch_n; pitch_d;
+     on_ground; tick] =>
+      if (px_d <=? 0) || (py_d <=? 0) || (pz_d <=? 0) ||
+         (vx_d <=? 0) || (vy_d <=? 0) || (vz_d <=? 0) ||
+         (yaw_d <=? 0) || (pitch_d <=? 0)
+      then None
+      else
+        Some (mk_game_state
+          (mk_vec3 (Qmake px_n (Z.to_pos px_d))
+                   (Qmake py_n (Z.to_pos py_d))
+                   (Qmake pz_n (Z.to_pos pz_d)))
+          (mk_vec3 (Qmake vx_n (Z.to_pos vx_d))
+                   (Qmake vy_n (Z.to_pos vy_d))
+                   (Qmake vz_n (Z.to_pos vz_d)))
+          (Qmake yaw_n   (Z.to_pos yaw_d))
+          (Qmake pitch_n (Z.to_pos pitch_d))
+          (negb (on_ground =? 0))
+          []
+          tick)
+  | _ => None
+  end.
+
+(** Advance the world by one frame.  For this phase the only change
+    is incrementing [gs_tick]; movement, look, and collision logic
+    will be added in subsequent tasks. *)
+Definition step_world (gs : game_state) (_input : input_snapshot)
+    : game_state :=
+  mk_game_state
+    (gs_position gs)
+    (gs_velocity gs)
+    (gs_yaw gs)
+    (gs_pitch gs)
+    (gs_on_ground gs)
+    (gs_entities gs)
+    (gs_tick gs + 1).
+
+(** Bridge-facing word-level entry point for per-frame stepping.
+    Takes the current game state as a word list (from
+    [game_state_to_words]) plus the packed input snapshot, and
+    returns the updated word list.  A malformed input word list is
+    passed through unchanged. *)
+Definition step_world_words (ws : list Z) (input : input_snapshot)
+    : list Z :=
+  match game_state_from_words ws with
+  | None    => ws
+  | Some gs => game_state_to_words (step_world gs input)
+  end.
+
+(** Bridge-facing entry point for [load_world].  Returns the initial
+    game-state word list from parsed entity data.  Used alongside
+    [initial_visible_faces_from_inputs] to populate the first
+    render snapshot. *)
+Definition initial_game_state_words_from_entities
+    (entities : list bsp_entity) : list Z :=
+  game_state_to_words (game_state_from_entities entities).
+
+(* ------------------------------------------------------------------ *)
+(** ** Correctness lemmas for world stepping                           *)
+(* ------------------------------------------------------------------ *)
+
+Lemma game_state_to_words_length : forall gs,
+  length (game_state_to_words gs) = game_state_words_count.
+Proof.
+  intros gs. unfold game_state_to_words, q_words, game_state_words_count.
+  repeat rewrite length_app. simpl. reflexivity.
+Qed.
+
+(** Stepping preserves position. *)
+Lemma step_world_position : forall gs input,
+  gs_position (step_world gs input) = gs_position gs.
+Proof. reflexivity. Qed.
+
+(** Stepping preserves velocity. *)
+Lemma step_world_velocity : forall gs input,
+  gs_velocity (step_world gs input) = gs_velocity gs.
+Proof. reflexivity. Qed.
+
+(** Stepping preserves orientation. *)
+Lemma step_world_yaw : forall gs input,
+  gs_yaw (step_world gs input) = gs_yaw gs.
+Proof. reflexivity. Qed.
+
+Lemma step_world_pitch : forall gs input,
+  gs_pitch (step_world gs input) = gs_pitch gs.
+Proof. reflexivity. Qed.
+
+(** Stepping increments the tick counter. *)
+Lemma step_world_tick : forall gs input,
+  gs_tick (step_world gs input) = gs_tick gs + 1.
+Proof. reflexivity. Qed.
+
+(** Helper: [Z.pos p] is never [<=? 0]. *)
+Lemma Z_pos_leb_0 : forall p : positive,
+  (Z.pos p <=? 0) = false.
+Proof.
+  intro p. apply Z.leb_gt. apply Pos2Z.is_pos.
+Qed.
+
+(** [game_state_to_words] round-trips through [game_state_from_words]
+    for states with an empty entity list. *)
+Lemma game_state_roundtrip : forall gs,
+  gs_entities gs = [] ->
+  game_state_from_words (game_state_to_words gs) = Some gs.
+Proof.
+  intros gs Hnil.
+  destruct gs as [[px py pz] [vx vy vz] yaw pitch grounded ents tick].
+  simpl in Hnil. subst ents.
+  (* Destruct each Q into num/den so Z.to_pos (Z.pos den) = den by reflexivity. *)
+  destruct px as [pxn pxd], py as [pyn pyd], pz as [pzn pzd].
+  destruct vx as [vxn vxd], vy as [vyn vyd], vz as [vzn vzd].
+  destruct yaw as [yn yd], pitch as [pn pd].
+  unfold game_state_to_words, game_state_from_words, q_words. simpl.
+  repeat rewrite Z_pos_leb_0. simpl.
+  destruct grounded; reflexivity.
+Qed.
+
+(** Serialized word count matches [game_state_words_count]. *)
+Lemma initial_game_state_words_from_entities_length : forall entities,
+  length (initial_game_state_words_from_entities entities) =
+  game_state_words_count.
+Proof.
+  intros entities. unfold initial_game_state_words_from_entities.
+  apply game_state_to_words_length.
+Qed.

--- a/theories/GameState.v
+++ b/theories/GameState.v
@@ -1027,6 +1027,18 @@ Lemma step_pitch_clamps_high :
   step_pitch 10%Q 100%Q = pitch_limit.
 Proof. vm_compute. reflexivity. Qed.
 
+Lemma step_pitch_clamps_low :
+  step_pitch (-10)%Q (-100)%Q = (- pitch_limit)%Q.
+Proof. vm_compute. reflexivity. Qed.
+
+Lemma step_world_turn_then_move_example :
+  let pos :=
+    gs_position
+      (step_world game_state_init
+        (mk_input_snapshot true false false false false 90%Q 0%Q 1000)) in
+  v3_x pos == 0 /\ v3_y pos == 320 /\ v3_z pos == 0.
+Proof. vm_compute. repeat split; reflexivity. Qed.
+
 Lemma step_world_forward_example :
   let pos :=
     gs_position
@@ -1042,6 +1054,23 @@ Lemma step_world_right_at_ninety_example :
         (mk_game_state vec3_zero vec3_zero 90%Q 0 true [] 0)
         (mk_input_snapshot false false false true false 0%Q 0%Q 1000)) in
   v3_x pos == -320 /\ v3_y pos == 0 /\ v3_z pos == 0.
+Proof. vm_compute. repeat split; reflexivity. Qed.
+
+Lemma step_world_conflicting_axes_cancel_example :
+  let pos :=
+    gs_position
+      (step_world game_state_init
+        (mk_input_snapshot true true true true false 0%Q 0%Q 1000)) in
+  v3_x pos == 0 /\ v3_y pos == 0 /\ v3_z pos == 0.
+Proof. vm_compute. repeat split; reflexivity. Qed.
+
+Lemma step_world_zero_dt_preserves_position_example :
+  let pos :=
+    gs_position
+      (step_world
+        (mk_game_state (mk_vec3 5 6 7) vec3_zero 0 0 true [] 0)
+        (mk_input_snapshot true false false false false 0%Q 0%Q 0)) in
+  v3_x pos == 5 /\ v3_y pos == 6 /\ v3_z pos == 7.
 Proof. vm_compute. repeat split; reflexivity. Qed.
 
 (** Helper: [Z.pos p] is never [<=? 0]. *)
@@ -1129,6 +1158,16 @@ Lemma step_world_in_world_empty_applies_gravity :
       (mk_input_snapshot false false false false false 0%Q 0%Q 1000) in
   v3_z (gs_position stepped) == -800 /\ gs_on_ground stepped = false.
 Proof. vm_compute. split; reflexivity. Qed.
+
+Lemma step_world_in_world_grounded_jump_example :
+  let stepped :=
+    step_world_in_world sample_floor_world
+      (mk_game_state (mk_vec3 0 0 17) vec3_zero 0 0 false [] 0)
+      (mk_input_snapshot false false false false true 0%Q 0%Q 100) in
+  v3_z (gs_position stepped) == 44 /\
+  v3_z (gs_velocity stepped) == jump_speed /\
+  gs_on_ground stepped = false.
+Proof. vm_compute. repeat split; reflexivity. Qed.
 
 Lemma brush_blocks_playerb_sample_solid :
   brush_blocks_playerb [sample_solid_texture] (mk_collision_brush_input 0 6 0) = true.


### PR DESCRIPTION
Fixes #25.

This PR completes the player-control port so desktop and mobile inputs now drive the same Rocq-owned movement, camera, collision, and frame-step behavior in the browser shell. It also lands the proof and documentation pass that makes those control semantics easier to inspect, trust, and maintain.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (5)</summary>

- [x] Define Rocq control snapshots and movement semantics <!-- type:spec -->
- [x] Add BSP collision and grounded physics to GameState <!-- type:spec -->
- [x] Bridge Rocq world stepping and frame timing into the browser shell <!-- type:spec -->
- [x] Wire desktop pointer-lock camera controls to Rocq <!-- type:spec -->
- [x] Add responsive mobile touch controls for play <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->