### PR TITLE
Port the minimum entity and trigger logic required by the demo level (closes #26)

### DIFF
--- a/V1_CHECKLIST.md
+++ b/V1_CHECKLIST.md
@@ -24,6 +24,35 @@ Many Deaths").  Reasons:
   demo license; asset packaging is tracked separately in
   [issue #14](https://github.com/rhencke/orly/issues/14).
 
+## q3dm1 entity scope for issue #26
+
+The v1 gameplay path for q3dm1 intentionally depends on a very small slice of
+the Quake 3 entity system.  The following entity families are **in scope** for
+[issue #26](https://github.com/rhencke/orly/issues/26):
+
+- `worldspawn` only as the static BSP container already loaded for geometry,
+  rendering, and collision; no additional worldspawn-specific gameplay logic is
+  required here.
+- `info_player_deathmatch` for spawn selection and restart placement.
+- `trigger_push` for the single q3dm1 jump pad that must launch the player when
+  crossed.
+- `target_position` only where referenced by a `trigger_push`, so Rocq can
+  derive the jump-pad launch direction from BSP entity data instead of
+  hard-coding it in JavaScript.
+
+The following entity families are **deferred** for v1 unless a later q3dm1
+investigation proves one is unexpectedly required for the acceptance path:
+
+- Movers and doors such as `func_door`, `func_button`, `func_plat`, and other
+  brush-model interactions.
+- Teleporters and destination entities such as `trigger_teleport` and
+  `misc_teleporter_dest`.
+- Pickups and inventory-affecting items such as health, armor, weapons, ammo,
+  and powerups.
+- Damage, scoring, scripting, or combat-related entities such as
+  `trigger_hurt`, `target_speaker`, `target_delay`, `target_print`, bots, and
+  weapon logic.
+
 ## Acceptance checklist
 
 ### Load and deployment

--- a/docs/index.html
+++ b/docs/index.html
@@ -712,6 +712,7 @@
           faces: bsp.faces,
           textures: bsp.textures,
           planes: bsp.planes,
+          models: bsp.models,
           brushes: bsp.brushes,
           brushSides: bsp.brushSides,
         });

--- a/docs/rocq_bridge.js
+++ b/docs/rocq_bridge.js
@@ -59,6 +59,14 @@ function formatCollisionTextures(textures) {
   return `[${textures.map(formatCollisionTexture).join('; ')}]`;
 }
 
+function formatModel(model) {
+  return `(mk_collision_model_input ${model.firstBrush} ${model.numBrushes})`;
+}
+
+function formatModels(models) {
+  return `[${models.map(formatModel).join('; ')}]`;
+}
+
 function formatFace(face) {
   return `(mk_render_face_input ${face.texture} ${face.type} ${face.nVertexes} ` +
     `${face.nMeshverts} ${face.sizeX} ${face.sizeY})`;
@@ -94,15 +102,11 @@ function formatBrushSides(brushSides) {
 }
 
 function formatCollisionWorld(world) {
-  const blockingBrushes = world.brushes.filter(brush => {
-    const texture = world.textures[brush.textureIndex];
-    if (!texture) return false;
-    return (texture.contents & (CONTENTS_SOLID | CONTENTS_PLAYERCLIP)) !== 0;
-  });
   return `(mk_collision_world_input ` +
     `${formatPlanes(world.planes)} ` +
     `${formatCollisionTextures(world.textures)} ` +
-    `${formatBrushes(blockingBrushes)} ` +
+    `${formatModels(world.models || [])} ` +
+    `${formatBrushes(world.brushes)} ` +
     `${formatBrushSides(world.brushSides)})`;
 }
 

--- a/docs/rocq_bridge.js
+++ b/docs/rocq_bridge.js
@@ -4,7 +4,7 @@ const DEG_TO_RAD = Math.PI / 180;
 const BRIDGE_VERSION = 1;
 const BRIDGE_HELPERS_DEFINITION = 'Definition step_world_words_in_world';
 const CAMERA_WORDS_COUNT = 10;
-const GAME_STATE_WORDS_COUNT = 18;
+const MIN_GAME_STATE_WORDS_COUNT = 19;
 const GEOMETRY_Q_SCALE = 1000000;
 const CONTENTS_SOLID = 1;
 const CONTENTS_PLAYERCLIP = 65536;
@@ -155,6 +155,8 @@ function cameraSnapshotFromWords(words) {
  *   14-15 pitch         (Q rational, num/den)
  *   16    on_ground
  *   17    tick
+ *   18    entity_count
+ *   19... serialized entity states
  */
 function cameraSnapshotFromGameStateWords(words) {
   const toQ = (n, d) => n / d;
@@ -259,9 +261,9 @@ async function evalInitialGameStateWords(manager, sid, world) {
     `${formatEntities(world.entities)}).`;
   const messages = await manager.coq.queryPromise(sid, ['Vernac', command]);
   const words = parseZList(flattenMessages(manager, messages));
-  if (words.length !== GAME_STATE_WORDS_COUNT) {
+  if (words.length < MIN_GAME_STATE_WORDS_COUNT) {
     throw new Error(
-      `expected ${GAME_STATE_WORDS_COUNT} game-state words, got ${words.length}`);
+      `expected at least ${MIN_GAME_STATE_WORDS_COUNT} game-state words, got ${words.length}`);
   }
   return words;
 }
@@ -280,9 +282,9 @@ async function evalStepWorldWords(manager, sid, collisionWorldExpr, gsWords, inp
     `${formatZList(gsWords)} ${formatInputSnapshot(inputSnapshot)}).`;
   const messages = await manager.coq.queryPromise(sid, ['Vernac', command]);
   const words = parseZList(flattenMessages(manager, messages));
-  if (words.length !== GAME_STATE_WORDS_COUNT) {
+  if (words.length < MIN_GAME_STATE_WORDS_COUNT) {
     throw new Error(
-      `expected ${GAME_STATE_WORDS_COUNT} game-state words from step, got ${words.length}`);
+      `expected at least ${MIN_GAME_STATE_WORDS_COUNT} game-state words from step, got ${words.length}`);
   }
   return words;
 }

--- a/docs/theories/BspCore.v
+++ b/docs/theories/BspCore.v
@@ -437,12 +437,33 @@ Definition key_origin : list Z :=
 Definition key_angle : list Z :=
   [97; 110; 103; 108; 101].
 
+(** ASCII encoding of "model". *)
+Definition key_model : list Z :=
+  [109; 111; 100; 101; 108].
+
+(** ASCII encoding of "target". *)
+Definition key_target : list Z :=
+  [116; 97; 114; 103; 101; 116].
+
+(** ASCII encoding of "targetname". *)
+Definition key_targetname : list Z :=
+  [116; 97; 114; 103; 101; 116; 110; 97; 109; 101].
+
+(** ASCII encoding of "trigger_push". *)
+Definition val_trigger_push : list Z :=
+  [116; 114; 105; 103; 103; 101; 114; 95; 112; 117; 115; 104].
+
+(** ASCII encoding of "target_position". *)
+Definition val_target_position : list Z :=
+  [116; 97; 114; 103; 101; 116; 95; 112; 111; 115; 105; 116; 105; 111; 110].
+
 (* ------------------------------------------------------------------ *)
 (** ** Integer value parser                                             *)
 (* ------------------------------------------------------------------ *)
 
 Definition ascii_minus : Z := 45.   (** '-' *)
 Definition ascii_space : Z := 32.   (** ' ' *)
+Definition ascii_star  : Z := 42.   (** '*' *)
 
 (** True iff [c] is an ASCII decimal digit. *)
 Definition is_digit (c : Z) : bool := (48 <=? c) && (c <=? 57).
@@ -484,6 +505,22 @@ Definition parse_int (cs : list Z) : option (Z * list Z) :=
            then let (n, tail) := scan_digits cs 0 (length cs) in
                 Some (n, tail)
            else None
+  end.
+
+(** Parse an inline BSP submodel reference of the form ["*N"].
+    Returns [Some N] iff the string begins with ['*'], the remainder
+    parses as a decimal integer, the parse consumes the full string,
+    and [N] is non-negative. *)
+Definition parse_inline_model_ref (cs : list Z) : option Z :=
+  match cs with
+  | c :: rest =>
+      if c =? ascii_star then
+        match parse_int rest with
+        | Some (n, []) => if n <? 0 then None else Some n
+        | _            => None
+        end
+      else None
+  | [] => None
   end.
 
 (* ------------------------------------------------------------------ *)
@@ -528,6 +565,21 @@ Proof. vm_compute. reflexivity. Qed.
 
 (** Negative integer. *)
 Lemma parse_int_neg_1 : parse_int [45; 49] = Some (-1, []).
+Proof. vm_compute. reflexivity. Qed.
+
+(** A well-formed inline model reference parses successfully. *)
+Lemma parse_inline_model_ref_pos :
+  parse_inline_model_ref [42; 49; 50] = Some 12.
+Proof. vm_compute. reflexivity. Qed.
+
+(** Negative inline model references are rejected. *)
+Lemma parse_inline_model_ref_neg :
+  parse_inline_model_ref [42; 45; 49] = None.
+Proof. vm_compute. reflexivity. Qed.
+
+(** Missing the leading ['*'] is not a valid inline model reference. *)
+Lemma parse_inline_model_ref_missing_star :
+  parse_inline_model_ref [49; 50] = None.
 Proof. vm_compute. reflexivity. Qed.
 (** * Game-state and render-snapshot types for the Rocq game core.
 
@@ -935,16 +987,20 @@ Definition parse_origin_vec3 (cs : list Z) : option vec3 :=
               | _ => None
               end
           end
-      | _ => None
-      end
+       | _ => None
+       end
+   end.
+
+(** True iff entity [e] has the given classname. *)
+Definition entity_classname_eqb (e : bsp_entity) (classname : list Z) : bool :=
+  match entity_get_val e key_classname with
+  | Some v => list_Z_eqb v classname
+  | None   => false
   end.
 
 (** True iff entity [e] has classname [info_player_deathmatch]. *)
 Definition is_spawn_entity (e : bsp_entity) : bool :=
-  match entity_get_val e key_classname with
-  | Some v => list_Z_eqb v val_info_player_deathmatch
-  | None   => false
-  end.
+  entity_classname_eqb e val_info_player_deathmatch.
 
 (** Extract the world-space origin from a spawn entity.
     Returns [None] if no [origin] key is present or the value is
@@ -966,6 +1022,74 @@ Definition spawn_yaw_of_entity (e : bsp_entity) : Q :=
       end
   | None => 0
   end.
+
+(* ------------------------------------------------------------------ *)
+(** ** Trigger metadata extraction from entity data                     *)
+(* ------------------------------------------------------------------ *)
+
+Record trigger_push_metadata : Type := mk_trigger_push_metadata
+  { tpm_model_index : Z
+  ; tpm_target_name : list Z
+  }.
+
+Record target_position_metadata : Type := mk_target_position_metadata
+  { tpos_target_name : list Z
+  ; tpos_origin      : vec3
+  }.
+
+(** True iff entity [e] has classname [trigger_push]. *)
+Definition is_trigger_push_entity (e : bsp_entity) : bool :=
+  entity_classname_eqb e val_trigger_push.
+
+(** True iff entity [e] has classname [target_position]. *)
+Definition is_target_position_entity (e : bsp_entity) : bool :=
+  entity_classname_eqb e val_target_position.
+
+(** Extract the inline BSP submodel index from an entity's [model] key. *)
+Definition entity_model_index (e : bsp_entity) : option Z :=
+  match entity_get_val e key_model with
+  | Some v => parse_inline_model_ref v
+  | None   => None
+  end.
+
+(** Extract the target name an entity points at via its [target] key. *)
+Definition entity_target_name (e : bsp_entity) : option (list Z) :=
+  entity_get_val e key_target.
+
+(** Extract the name by which another entity can target this one. *)
+Definition entity_targetname (e : bsp_entity) : option (list Z) :=
+  entity_get_val e key_targetname.
+
+(** Extract a [target_position] origin from entity data. *)
+Definition target_position_origin_of_entity (e : bsp_entity) : option vec3 :=
+  match entity_get_val e key_origin with
+  | Some v => parse_origin_vec3 v
+  | None   => None
+  end.
+
+(** Parse the metadata v1 needs from a [trigger_push] entity.
+    The trigger must carry both an inline [model] reference and a
+    [target] name so later world-building code can resolve it. *)
+Definition parse_trigger_push_metadata (e : bsp_entity)
+    : option trigger_push_metadata :=
+  if is_trigger_push_entity e then
+    match entity_model_index e, entity_target_name e with
+    | Some model_index, Some target_name =>
+        Some (mk_trigger_push_metadata model_index target_name)
+    | _, _ => None
+    end
+  else None.
+
+(** Parse the metadata v1 needs from a [target_position] entity. *)
+Definition parse_target_position_metadata (e : bsp_entity)
+    : option target_position_metadata :=
+  if is_target_position_entity e then
+    match entity_targetname e, target_position_origin_of_entity e with
+    | Some target_name, Some origin =>
+        Some (mk_target_position_metadata target_name origin)
+    | _, _ => None
+    end
+  else None.
 
 (** [select_spawn_point entities] returns the position and yaw of the
     first [info_player_deathmatch] entity that has a parseable [origin].
@@ -1174,6 +1298,33 @@ Proof. vm_compute. reflexivity. Qed.
 Lemma parse_origin_neg_example :
   parse_origin_vec3 [45; 52; 56; 32; 49; 50; 56; 32; 45; 56] =
     Some (mk_vec3 (inject_Z (-48)) (inject_Z 128) (inject_Z (-8))).
+Proof. vm_compute. reflexivity. Qed.
+
+Lemma parse_trigger_push_metadata_example :
+  parse_trigger_push_metadata
+    [ (key_classname, val_trigger_push)
+    ; (key_model, [42; 51])
+    ; (key_target, [112; 97; 100; 49])
+    ] =
+  Some (mk_trigger_push_metadata 3 [112; 97; 100; 49]).
+Proof. vm_compute. reflexivity. Qed.
+
+Lemma parse_trigger_push_metadata_requires_target :
+  parse_trigger_push_metadata
+    [ (key_classname, val_trigger_push)
+    ; (key_model, [42; 51])
+    ] = None.
+Proof. vm_compute. reflexivity. Qed.
+
+Lemma parse_target_position_metadata_example :
+  parse_target_position_metadata
+    [ (key_classname, val_target_position)
+    ; (key_targetname, [112; 97; 100; 49])
+    ; (key_origin, [49; 50; 56; 32; 48; 32; 50; 53; 54])
+    ] =
+  Some (mk_target_position_metadata
+          [112; 97; 100; 49]
+          (mk_vec3 128 0 256)).
 Proof. vm_compute. reflexivity. Qed.
 
 (** An empty entity list has no spawn points. *)

--- a/docs/theories/BspCore.v
+++ b/docs/theories/BspCore.v
@@ -635,6 +635,13 @@ Definition vec3_add (a b : vec3) : vec3 :=
     (v3_y a + v3_y b)
     (v3_z a + v3_z b).
 
+(** Vector subtraction. *)
+Definition vec3_sub (a b : vec3) : vec3 :=
+  mk_vec3
+    (v3_x a - v3_x b)
+    (v3_y a - v3_y b)
+    (v3_z a - v3_z b).
+
 (** Scalar multiplication of a vector. *)
 Definition vec3_scale (k : Q) (v : vec3) : vec3 :=
   mk_vec3
@@ -726,10 +733,17 @@ Record collision_brush_input : Type := mk_collision_brush_input
 Record collision_brush_side_input : Type := mk_collision_brush_side_input
   { cbsi_plane_index : Z }.
 
+(** Minimal BSP submodel data needed for trigger volumes. *)
+Record collision_model_input : Type := mk_collision_model_input
+  { cmi_first_brush : Z
+  ; cmi_num_brushes : Z
+  }.
+
 (** Static BSP collision data provided by the browser at world load. *)
 Record collision_world_input : Type := mk_collision_world_input
   { cwi_planes      : list collision_plane_input
   ; cwi_textures    : list collision_texture_input
+  ; cwi_models      : list collision_model_input
   ; cwi_brushes     : list collision_brush_input
   ; cwi_brush_sides : list collision_brush_side_input
   }.
@@ -801,7 +815,7 @@ Definition visible_face_indices
   visible_face_indices_aux faces textures 0.
 
 Definition collision_world_empty : collision_world_input :=
-  mk_collision_world_input [] [] [] [].
+  mk_collision_world_input [] [] [] [] [].
 
 Definition contents_solid : Z := 1.
 
@@ -1246,6 +1260,7 @@ Definition player_radius : Q := 16.
 Definition ground_probe_distance : Q := 1.
 Definition gravity_accel : Q := 800.
 Definition jump_speed : Q := 270.
+Definition trigger_push_travel_time : Q := 1.
 Definition collision_sweep_iterations : nat := 8%nat.
 Definition collision_motion_substeps : nat := 16%nat.
 Definition collision_motion_substep_scale : Q := (1 # 16)%Q.
@@ -1287,6 +1302,19 @@ Definition point_collides_brushb
     end
   else false.
 
+Definition point_collides_brush_geometryb
+    (world : collision_world_input) (pos : vec3) (br : collision_brush_input) : bool :=
+  match Z.max 0 (cbi_num_sides br) with
+  | 0 => false
+  | n =>
+      point_collides_brush_aux
+        (cwi_planes world)
+        (cwi_brush_sides world)
+        pos
+        (cbi_first_side br)
+        (Z.to_nat n)
+  end.
+
 Fixpoint point_collides_world_aux
     (world : collision_world_input) (pos : vec3)
     (brushes : list collision_brush_input) : bool :=
@@ -1300,6 +1328,69 @@ Fixpoint point_collides_world_aux
 Definition point_collides_worldb
     (world : collision_world_input) (pos : vec3) : bool :=
   point_collides_world_aux world pos (cwi_brushes world).
+
+Fixpoint point_collides_model_brushes_aux
+    (world : collision_world_input) (pos : vec3)
+    (brush_index : Z) (fuel : nat) : bool :=
+  match fuel with
+  | O => false
+  | S fuel' =>
+      match nth_z (cwi_brushes world) brush_index with
+      | None => false
+      | Some br =>
+          if point_collides_brush_geometryb world pos br
+          then true
+          else point_collides_model_brushes_aux world pos (brush_index + 1) fuel'
+      end
+  end.
+
+Definition point_collides_modelb
+    (world : collision_world_input) (pos : vec3) (model : collision_model_input) : bool :=
+  match Z.max 0 (cmi_num_brushes model) with
+  | 0 => false
+  | n =>
+      point_collides_model_brushes_aux
+        world pos (cmi_first_brush model) (Z.to_nat n)
+  end.
+
+Definition entity_inside_trigger_modelb
+    (world : collision_world_input) (pos : vec3) (es : entity_state) : bool :=
+  match nth_z (cwi_models world) (es_model_index es) with
+  | Some model => point_collides_modelb world pos model
+  | None => false
+  end.
+
+Definition trigger_push_velocity
+    (pos target_origin : vec3) : vec3 :=
+  let delta := vec3_sub target_origin pos in
+  let t := trigger_push_travel_time in
+  mk_vec3
+    (v3_x delta / t)
+    (v3_y delta / t)
+    ((v3_z delta / t) + gravity_accel * t / 2)%Q.
+
+Fixpoint apply_trigger_pushes
+    (world : collision_world_input) (pos : vec3)
+    (entities : list entity_state)
+    : option vec3 * list entity_state :=
+  match entities with
+  | [] => (None, [])
+  | es :: rest =>
+      let inside := entity_inside_trigger_modelb world pos es in
+      let fired := es_active es && inside in
+      let updated :=
+        mk_entity_state
+          (es_entity_index es)
+          (es_model_index es)
+          (es_origin es)
+          (negb inside) in
+      let '(rest_impulse, rest_entities) := apply_trigger_pushes world pos rest in
+      let impulse :=
+        if fired
+        then Some (trigger_push_velocity pos (es_origin es))
+        else rest_impulse in
+      (impulse, updated :: rest_entities)
+  end.
 
 Fixpoint sweep_to_contact
     (world : collision_world_input) (lo hi : vec3) (fuel : nat) : vec3 :=
@@ -1692,19 +1783,31 @@ Definition step_world_in_world
   let '(position, vertical_blocked) :=
     resolve_motion_substeps world horizontal_pos vertical_delta in
   let landed := vertical_blocked && qleb desired_vel_z 0 in
-  let on_ground := landed || grounded_by_worldb world position in
-  let velocity :=
+  let base_on_ground := landed || grounded_by_worldb world position in
+  let base_velocity :=
     mk_vec3
       (if horizontal_blocked then 0 else v3_x desired_planar)
       (if horizontal_blocked then 0 else v3_y desired_planar)
       (if vertical_blocked then 0 else desired_vel_z) in
+  let '(trigger_impulse, entities) :=
+    apply_trigger_pushes world position (gs_entities gs) in
+  let velocity :=
+    match trigger_impulse with
+    | Some impulse => impulse
+    | None => base_velocity
+    end in
+  let on_ground :=
+    match trigger_impulse with
+    | Some _ => false
+    | None => base_on_ground
+    end in
   mk_game_state
     position
     velocity
     yaw
     pitch
     on_ground
-    (gs_entities gs)
+    entities
     (gs_tick gs + 1).
 
 (** Bridge-facing word-level entry point for per-frame stepping.
@@ -1892,10 +1995,11 @@ Definition sample_floor_world : collision_world_input :=
     ; mk_collision_plane_input (-1)   0    0 1024
     ; mk_collision_plane_input   0    1    0 1024
     ; mk_collision_plane_input   0  (-1)   0 1024
-    ; mk_collision_plane_input   0    0    1    0
-    ; mk_collision_plane_input   0    0  (-1)  64
-    ]
+     ; mk_collision_plane_input   0    0    1    0
+     ; mk_collision_plane_input   0    0  (-1)  64
+     ]
     [sample_solid_texture]
+    []
     [mk_collision_brush_input 0 6 0]
     [ mk_collision_brush_side_input 0
     ; mk_collision_brush_side_input 1
@@ -1911,10 +2015,31 @@ Definition sample_wall_world : collision_world_input :=
     ; mk_collision_plane_input (-1)   0    0  (-32)
     ; mk_collision_plane_input   0    1    0 1024
     ; mk_collision_plane_input   0  (-1)   0 1024
-    ; mk_collision_plane_input   0    0    1 1024
-    ; mk_collision_plane_input   0    0  (-1) 1024
-    ]
+     ; mk_collision_plane_input   0    0    1 1024
+     ; mk_collision_plane_input   0    0  (-1) 1024
+     ]
     [sample_solid_texture]
+    []
+    [mk_collision_brush_input 0 6 0]
+    [ mk_collision_brush_side_input 0
+    ; mk_collision_brush_side_input 1
+    ; mk_collision_brush_side_input 2
+    ; mk_collision_brush_side_input 3
+    ; mk_collision_brush_side_input 4
+    ; mk_collision_brush_side_input 5
+    ].
+
+Definition sample_trigger_world : collision_world_input :=
+  mk_collision_world_input
+    [ mk_collision_plane_input   1    0    0   32
+    ; mk_collision_plane_input (-1)   0    0   32
+    ; mk_collision_plane_input   0    1    0   32
+    ; mk_collision_plane_input   0  (-1)   0   32
+    ; mk_collision_plane_input   0    0    1    0
+    ; mk_collision_plane_input   0    0  (-1)  64
+    ]
+    []
+    [mk_collision_model_input 0 1]
     [mk_collision_brush_input 0 6 0]
     [ mk_collision_brush_side_input 0
     ; mk_collision_brush_side_input 1
@@ -1956,3 +2081,23 @@ Proof. vm_compute. reflexivity. Qed.
 Lemma point_collides_worldb_sample_wall :
   point_collides_worldb sample_wall_world (mk_vec3 16 0 128) = true.
 Proof. vm_compute. reflexivity. Qed.
+
+Lemma point_collides_modelb_sample_trigger :
+  point_collides_modelb sample_trigger_world (mk_vec3 0 0 16)
+    (mk_collision_model_input 0 1) = true.
+Proof. vm_compute. reflexivity. Qed.
+
+Lemma step_world_in_world_trigger_push_example :
+  let stepped :=
+    step_world_in_world sample_trigger_world
+      (mk_game_state
+         (mk_vec3 0 0 16)
+         vec3_zero
+         0 0 false
+         [mk_entity_state 0 0 (mk_vec3 0 0 256) true]
+         0)
+      input_snapshot_zero in
+  v3_z (gs_velocity stepped) == 640 /\
+  gs_on_ground stepped = false /\
+  gs_entities stepped = [mk_entity_state 0 0 (mk_vec3 0 0 256) false].
+Proof. vm_compute. repeat split; reflexivity. Qed.

--- a/docs/theories/BspCore.v
+++ b/docs/theories/BspCore.v
@@ -674,7 +674,8 @@ Definition input_snapshot_zero : input_snapshot :=
     For v1, the primary entity type is [trigger_push] (jump pads). *)
 Record entity_state : Type := mk_entity_state
   { es_entity_index : Z       (** index into [bf_entities] *)
-  ; es_origin       : vec3    (** world-space position *)
+  ; es_model_index  : Z       (** inline BSP submodel index *)
+  ; es_origin       : vec3    (** resolved world-space target/origin *)
   ; es_active       : bool    (** whether the trigger is armed *)
   }.
 
@@ -1037,6 +1038,10 @@ Record target_position_metadata : Type := mk_target_position_metadata
   ; tpos_origin      : vec3
   }.
 
+Definition target_position_name_eqb
+    (target : target_position_metadata) (name : list Z) : bool :=
+  list_Z_eqb (tpos_target_name target) name.
+
 (** True iff entity [e] has classname [trigger_push]. *)
 Definition is_trigger_push_entity (e : bsp_entity) : bool :=
   entity_classname_eqb e val_trigger_push.
@@ -1091,6 +1096,61 @@ Definition parse_target_position_metadata (e : bsp_entity)
     end
   else None.
 
+Fixpoint collect_target_positions
+    (entities : list bsp_entity) : list target_position_metadata :=
+  match entities with
+  | [] => []
+  | e :: rest =>
+      match parse_target_position_metadata e with
+      | Some target => target :: collect_target_positions rest
+      | None        => collect_target_positions rest
+      end
+  end.
+
+Fixpoint find_target_position_origin
+    (targets : list target_position_metadata) (name : list Z) : option vec3 :=
+  match targets with
+  | [] => None
+  | target :: rest =>
+      if target_position_name_eqb target name
+      then Some (tpos_origin target)
+      else find_target_position_origin rest name
+  end.
+
+Fixpoint initial_trigger_states_from_entities_aux
+    (entities : list bsp_entity)
+    (targets : list target_position_metadata)
+    (entity_index : Z) : list entity_state :=
+  match entities with
+  | [] => []
+  | e :: rest =>
+      let rest_states :=
+        initial_trigger_states_from_entities_aux rest targets (entity_index + 1) in
+      match parse_trigger_push_metadata e with
+      | Some trigger =>
+          match find_target_position_origin targets (tpm_target_name trigger) with
+          | Some origin =>
+              mk_entity_state
+                entity_index
+                (tpm_model_index trigger)
+                origin
+                true :: rest_states
+          | None => rest_states
+          end
+      | None => rest_states
+      end
+  end.
+
+(** Resolve the initial trigger/jump-pad state directly from the BSP
+    entity list by pairing [trigger_push] entities with the
+    [target_position] entities they reference. *)
+Definition initial_trigger_states_from_entities
+    (entities : list bsp_entity) : list entity_state :=
+  initial_trigger_states_from_entities_aux
+    entities
+    (collect_target_positions entities)
+    0.
+
 (** [select_spawn_point entities] returns the position and yaw of the
     first [info_player_deathmatch] entity that has a parseable [origin].
     Returns [None] if no such entity exists. *)
@@ -1112,9 +1172,10 @@ Fixpoint select_spawn_point (entities : list bsp_entity)
     [entities]; if none exists, falls back to [game_state_init]. *)
 Definition game_state_from_entities (entities : list bsp_entity)
     : game_state :=
+  let trigger_states := initial_trigger_states_from_entities entities in
   match select_spawn_point entities with
-  | Some (pos, yaw) => mk_game_state pos vec3_zero yaw 0 true [] 0
-  | None            => game_state_init
+  | Some (pos, yaw) => mk_game_state pos vec3_zero yaw 0 true trigger_states 0
+  | None            => mk_game_state vec3_zero vec3_zero 0 0 true trigger_states 0
   end.
 
 (** End-to-end helper for the browser bridge: derive the initial camera
@@ -1327,6 +1388,27 @@ Lemma parse_target_position_metadata_example :
           (mk_vec3 128 0 256)).
 Proof. vm_compute. reflexivity. Qed.
 
+Lemma find_target_position_origin_example :
+  find_target_position_origin
+    [ mk_target_position_metadata [112; 97; 100; 49] (mk_vec3 128 0 256) ]
+    [112; 97; 100; 49] =
+  Some (mk_vec3 128 0 256).
+Proof. vm_compute. reflexivity. Qed.
+
+Lemma initial_trigger_states_from_entities_example :
+  initial_trigger_states_from_entities
+    [ ( (key_classname, val_trigger_push)
+        :: (key_model, [42; 51])
+        :: (key_target, [112; 97; 100; 49])
+        :: nil )
+    ; ( (key_classname, val_target_position)
+        :: (key_targetname, [112; 97; 100; 49])
+        :: (key_origin, [49; 50; 56; 32; 48; 32; 50; 53; 54])
+        :: nil )
+    ] =
+  [mk_entity_state 0 3 (mk_vec3 128 0 256) true].
+Proof. vm_compute. reflexivity. Qed.
+
 (** An empty entity list has no spawn points. *)
 Lemma select_spawn_point_nil :
   select_spawn_point [] = None.
@@ -1358,6 +1440,15 @@ Qed.
 (** A spawn-derived state starts grounded. *)
 Lemma game_state_from_entities_grounded : forall entities,
   gs_on_ground (game_state_from_entities entities) = true.
+Proof.
+  intros entities. unfold game_state_from_entities.
+  destruct (select_spawn_point entities) as [[[px py pz] yaw] |];
+    reflexivity.
+Qed.
+
+Lemma game_state_from_entities_entities : forall entities,
+  gs_entities (game_state_from_entities entities) =
+  initial_trigger_states_from_entities entities.
 Proof.
   intros entities. unfold game_state_from_entities.
   destruct (select_spawn_point entities) as [[[px py pz] yaw] |];

--- a/docs/theories/BspCore.v
+++ b/docs/theories/BspCore.v
@@ -1546,6 +1546,24 @@ Proof.
     reflexivity.
 Qed.
 
+(** When a spawn point is found, the initial position comes from it. *)
+Lemma game_state_from_entities_position : forall entities pos yaw,
+  select_spawn_point entities = Some (pos, yaw) ->
+  gs_position (game_state_from_entities entities) = pos.
+Proof.
+  intros entities pos yaw Hspawn.
+  unfold game_state_from_entities. rewrite Hspawn. reflexivity.
+Qed.
+
+(** When a spawn point is found, the initial yaw comes from it. *)
+Lemma game_state_from_entities_yaw : forall entities pos yaw,
+  select_spawn_point entities = Some (pos, yaw) ->
+  gs_yaw (game_state_from_entities entities) = yaw.
+Proof.
+  intros entities pos yaw Hspawn.
+  unfold game_state_from_entities. rewrite Hspawn. reflexivity.
+Qed.
+
 (** The bridge helper always yields the five serialized camera values. *)
 Lemma initial_camera_words_from_entities_length : forall entities,
   length (initial_camera_words_from_entities entities) = 10%nat.
@@ -2052,21 +2070,47 @@ Proof.
   intro p. apply Z.leb_gt. apply Pos2Z.is_pos.
 Qed.
 
-(** [game_state_to_words] round-trips through [game_state_from_words]
-    for states with an empty entity list. *)
+(** [entity_state_to_words] round-trips through [entity_state_from_words]
+    with any trailing payload preserved. *)
+Lemma entity_state_roundtrip : forall es tail,
+  entity_state_from_words (entity_state_to_words es ++ tail) =
+  Some (es, tail).
+Proof.
+  intros [entity_index model_index [ox oy oz] active] tail.
+  destruct ox as [oxn oxd], oy as [oyn oyd], oz as [ozn ozd].
+  unfold entity_state_to_words, entity_state_from_words, q_words. simpl.
+  destruct tail as [| z tail']; repeat rewrite Z_pos_leb_0; simpl;
+    destruct active; reflexivity.
+Qed.
+
+Lemma entity_states_roundtrip : forall entities,
+  entity_states_from_words_aux (length entities) (entity_states_to_words entities) =
+  Some (entities, []).
+Proof.
+  induction entities as [| es rest IH].
+  - reflexivity.
+  - cbn [length entity_states_from_words_aux entity_states_to_words].
+    rewrite entity_state_roundtrip.
+    rewrite IH. reflexivity.
+Qed.
+
+(** [game_state_to_words] round-trips through [game_state_from_words]. *)
 Lemma game_state_roundtrip : forall gs,
-  gs_entities gs = [] ->
   game_state_from_words (game_state_to_words gs) = Some gs.
 Proof.
-  intros gs Hnil.
+  intros gs.
   destruct gs as [[px py pz] [vx vy vz] yaw pitch grounded ents tick].
-  simpl in Hnil. subst ents.
   (* Destruct each Q into num/den so Z.to_pos (Z.pos den) = den by reflexivity. *)
   destruct px as [pxn pxd], py as [pyn pyd], pz as [pzn pzd].
   destruct vx as [vxn vxd], vy as [vyn vyd], vz as [vzn vzd].
   destruct yaw as [yn yd], pitch as [pn pd].
   unfold game_state_to_words, game_state_from_words, q_words. simpl.
   repeat rewrite Z_pos_leb_0. simpl.
+  assert ((Z.of_nat (length ents) <? 0) = false) as Hcount.
+  { apply Z.ltb_ge. lia. }
+  rewrite Hcount. simpl.
+  rewrite Nat2Z.id.
+  rewrite entity_states_roundtrip.
   destruct grounded; reflexivity.
 Qed.
 
@@ -2185,6 +2229,50 @@ Lemma point_collides_modelb_sample_trigger :
   point_collides_modelb sample_trigger_world (mk_vec3 0 0 16)
     (mk_collision_model_input 0 1) = true.
 Proof. vm_compute. reflexivity. Qed.
+
+Lemma apply_trigger_pushes_single_outside : forall world pos es,
+  entity_inside_trigger_modelb world pos es = false ->
+  apply_trigger_pushes world pos [es] =
+  (None,
+   [mk_entity_state
+      (es_entity_index es)
+      (es_model_index es)
+      (es_origin es)
+      true]).
+Proof.
+  intros world pos [entity_index model_index [ox oy oz] active] Hinside.
+  simpl in *. rewrite Hinside. destruct active; reflexivity.
+Qed.
+
+Lemma apply_trigger_pushes_single_inside_active : forall world pos es,
+  entity_inside_trigger_modelb world pos es = true ->
+  es_active es = true ->
+  apply_trigger_pushes world pos [es] =
+  (Some (trigger_push_velocity pos (es_origin es)),
+   [mk_entity_state
+      (es_entity_index es)
+      (es_model_index es)
+      (es_origin es)
+      false]).
+Proof.
+  intros world pos [entity_index model_index [ox oy oz] active] Hinside Hactive.
+  simpl in *. subst active. rewrite Hinside. reflexivity.
+Qed.
+
+Lemma apply_trigger_pushes_single_inside_inactive : forall world pos es,
+  entity_inside_trigger_modelb world pos es = true ->
+  es_active es = false ->
+  apply_trigger_pushes world pos [es] =
+  (None,
+   [mk_entity_state
+      (es_entity_index es)
+      (es_model_index es)
+      (es_origin es)
+      false]).
+Proof.
+  intros world pos [entity_index model_index [ox oy oz] active] Hinside Hactive.
+  simpl in *. subst active. rewrite Hinside. reflexivity.
+Qed.
 
 Lemma step_world_in_world_trigger_push_example :
   let stepped :=

--- a/docs/theories/BspCore.v
+++ b/docs/theories/BspCore.v
@@ -1616,16 +1616,30 @@ Qed.
 (** ** World-state serialization and frame stepping                    *)
 (* ------------------------------------------------------------------ *)
 
+(** Number of [Z] words produced per serialized [entity_state]. *)
+Definition entity_state_words_count : nat := 9.
+
 (** Number of [Z] words produced by [game_state_to_words] for a
     game state with an empty entity list. *)
-Definition game_state_words_count : nat := 18.
+Definition game_state_words_count : nat := 19.
+
+Definition entity_state_to_words (es : entity_state) : list Z :=
+  [es_entity_index es; es_model_index es] ++
+  q_words (v3_x (es_origin es)) ++
+  q_words (v3_y (es_origin es)) ++
+  q_words (v3_z (es_origin es)) ++
+  [if es_active es then 1 else 0].
+
+Fixpoint entity_states_to_words (entities : list entity_state) : list Z :=
+  match entities with
+  | [] => []
+  | es :: rest => entity_state_to_words es ++ entity_states_to_words rest
+  end.
 
 (** Serialize a [game_state] to a flat [list Z] suitable for
-    round-tripping through the JS bridge.  The entity list is
-    omitted; v1 entities carry no per-step dynamic state that
-    needs crossing the bridge boundary.
+    round-tripping through the JS bridge.
 
-    Word layout (18 entries):
+    Word layout (19 + 9 * entity_count entries):
     <<
        0  px_num   1  px_den
        2  py_num   3  py_den
@@ -1637,6 +1651,8 @@ Definition game_state_words_count : nat := 18.
       14 pch_num  15 pch_den
       16 on_ground          (0 = airborne, 1 = grounded)
       17 tick
+      18 entity_count
+      19... serialized entity states
     >>
 *)
 Definition game_state_to_words (gs : game_state) : list Z :=
@@ -1649,34 +1665,92 @@ Definition game_state_to_words (gs : game_state) : list Z :=
   q_words (gs_yaw gs) ++
   q_words (gs_pitch gs) ++
   [(if gs_on_ground gs then 1 else 0)] ++
-  [gs_tick gs].
+  [gs_tick gs] ++
+  [Z.of_nat (length (gs_entities gs))] ++
+  entity_states_to_words (gs_entities gs).
+
+Definition entity_state_from_words (ws : list Z)
+    : option (entity_state * list Z) :=
+  match ws with
+  | [entity_index; model_index;
+     ox_n; ox_d; oy_n; oy_d; oz_n; oz_d;
+     active] =>
+      if (ox_d <=? 0) || (oy_d <=? 0) || (oz_d <=? 0)
+      then None
+      else
+        Some
+          ( mk_entity_state
+              entity_index
+              model_index
+              (mk_vec3 (Qmake ox_n (Z.to_pos ox_d))
+                       (Qmake oy_n (Z.to_pos oy_d))
+                       (Qmake oz_n (Z.to_pos oz_d)))
+              (negb (active =? 0))
+          , []
+          )
+  | entity_index :: model_index ::
+    ox_n :: ox_d :: oy_n :: oy_d :: oz_n :: oz_d :: active :: rest =>
+      if (ox_d <=? 0) || (oy_d <=? 0) || (oz_d <=? 0)
+      then None
+      else
+        Some
+          ( mk_entity_state
+              entity_index
+              model_index
+              (mk_vec3 (Qmake ox_n (Z.to_pos ox_d))
+                       (Qmake oy_n (Z.to_pos oy_d))
+                       (Qmake oz_n (Z.to_pos oz_d)))
+              (negb (active =? 0))
+          , rest
+          )
+  | _ => None
+  end.
+
+Fixpoint entity_states_from_words_aux (count : nat) (ws : list Z)
+    : option (list entity_state * list Z) :=
+  match count with
+  | O => Some ([], ws)
+  | S count' =>
+      match entity_state_from_words ws with
+      | Some (es, rest) =>
+          match entity_states_from_words_aux count' rest with
+          | Some (entities, tail) => Some (es :: entities, tail)
+          | None => None
+          end
+      | None => None
+      end
+  end.
 
 (** Reconstruct a [game_state] from the word list produced by
     [game_state_to_words].  Returns [None] on a malformed list or
     any zero/negative denominator. *)
 Definition game_state_from_words (ws : list Z) : option game_state :=
   match ws with
-  | [px_n; px_d; py_n; py_d; pz_n; pz_d;
-     vx_n; vx_d; vy_n; vy_d; vz_n; vz_d;
-     yaw_n; yaw_d; pitch_n; pitch_d;
-     on_ground; tick] =>
+  | px_n :: px_d :: py_n :: py_d :: pz_n :: pz_d ::
+    vx_n :: vx_d :: vy_n :: vy_d :: vz_n :: vz_d ::
+    yaw_n :: yaw_d :: pitch_n :: pitch_d ::
+    on_ground :: tick :: entity_count :: entity_words =>
       if (px_d <=? 0) || (py_d <=? 0) || (pz_d <=? 0) ||
-         (vx_d <=? 0) || (vy_d <=? 0) || (vz_d <=? 0) ||
-         (yaw_d <=? 0) || (pitch_d <=? 0)
+          (vx_d <=? 0) || (vy_d <=? 0) || (vz_d <=? 0) ||
+          (yaw_d <=? 0) || (pitch_d <=? 0) || (entity_count <? 0)
       then None
       else
-        Some (mk_game_state
-          (mk_vec3 (Qmake px_n (Z.to_pos px_d))
-                   (Qmake py_n (Z.to_pos py_d))
-                   (Qmake pz_n (Z.to_pos pz_d)))
-          (mk_vec3 (Qmake vx_n (Z.to_pos vx_d))
-                   (Qmake vy_n (Z.to_pos vy_d))
-                   (Qmake vz_n (Z.to_pos vz_d)))
-          (Qmake yaw_n   (Z.to_pos yaw_d))
-          (Qmake pitch_n (Z.to_pos pitch_d))
-          (negb (on_ground =? 0))
-          []
-          tick)
+        match entity_states_from_words_aux (Z.to_nat entity_count) entity_words with
+        | Some (entities, []) =>
+            Some (mk_game_state
+              (mk_vec3 (Qmake px_n (Z.to_pos px_d))
+                       (Qmake py_n (Z.to_pos py_d))
+                       (Qmake pz_n (Z.to_pos pz_d)))
+              (mk_vec3 (Qmake vx_n (Z.to_pos vx_d))
+                       (Qmake vy_n (Z.to_pos vy_d))
+                       (Qmake vz_n (Z.to_pos vz_d)))
+              (Qmake yaw_n   (Z.to_pos yaw_d))
+              (Qmake pitch_n (Z.to_pos pitch_d))
+              (negb (on_ground =? 0))
+              entities
+              tick)
+        | _ => None
+        end
   | _ => None
   end.
 
@@ -1842,11 +1916,34 @@ Definition initial_game_state_words_from_entities
 (** ** Correctness lemmas for world stepping                           *)
 (* ------------------------------------------------------------------ *)
 
-Lemma game_state_to_words_length : forall gs,
-  length (game_state_to_words gs) = game_state_words_count.
+Lemma entity_state_to_words_length : forall es,
+  length (entity_state_to_words es) = entity_state_words_count.
 Proof.
-  intros gs. unfold game_state_to_words, q_words, game_state_words_count.
+  intros es. unfold entity_state_to_words, q_words, entity_state_words_count.
   repeat rewrite length_app. simpl. reflexivity.
+Qed.
+
+Lemma entity_states_to_words_length : forall entities,
+  length (entity_states_to_words entities) =
+  (entity_state_words_count * length entities)%nat.
+Proof.
+  induction entities as [| es rest IH]; simpl.
+  - reflexivity.
+  - destruct es as [entity_index model_index origin active].
+    destruct origin as [ox oy oz].
+    unfold entity_state_words_count in *. simpl in *.
+    rewrite IH. lia.
+Qed.
+
+Lemma game_state_to_words_length : forall gs,
+  length (game_state_to_words gs) =
+  (game_state_words_count +
+   entity_state_words_count * length (gs_entities gs))%nat.
+Proof.
+  intros [[px py pz] [vx vy vz] yaw pitch grounded entities tick].
+  unfold game_state_to_words, q_words, game_state_words_count, entity_state_words_count.
+  simpl.
+  rewrite entity_states_to_words_length. reflexivity.
 Qed.
 
 (** Stepping integrates position from the per-frame velocity. *)
@@ -1973,10 +2070,12 @@ Proof.
   destruct grounded; reflexivity.
 Qed.
 
-(** Serialized word count matches [game_state_words_count]. *)
+(** Serialized word count includes the per-entity payload. *)
 Lemma initial_game_state_words_from_entities_length : forall entities,
   length (initial_game_state_words_from_entities entities) =
-  game_state_words_count.
+  (game_state_words_count +
+   entity_state_words_count *
+   length (gs_entities (game_state_from_entities entities)))%nat.
 Proof.
   intros entities. unfold initial_game_state_words_from_entities.
   apply game_state_to_words_length.

--- a/theories/BspEntity.v
+++ b/theories/BspEntity.v
@@ -265,12 +265,33 @@ Definition key_origin : list Z :=
 Definition key_angle : list Z :=
   [97; 110; 103; 108; 101].
 
+(** ASCII encoding of "model". *)
+Definition key_model : list Z :=
+  [109; 111; 100; 101; 108].
+
+(** ASCII encoding of "target". *)
+Definition key_target : list Z :=
+  [116; 97; 114; 103; 101; 116].
+
+(** ASCII encoding of "targetname". *)
+Definition key_targetname : list Z :=
+  [116; 97; 114; 103; 101; 116; 110; 97; 109; 101].
+
+(** ASCII encoding of "trigger_push". *)
+Definition val_trigger_push : list Z :=
+  [116; 114; 105; 103; 103; 101; 114; 95; 112; 117; 115; 104].
+
+(** ASCII encoding of "target_position". *)
+Definition val_target_position : list Z :=
+  [116; 97; 114; 103; 101; 116; 95; 112; 111; 115; 105; 116; 105; 111; 110].
+
 (* ------------------------------------------------------------------ *)
 (** ** Integer value parser                                             *)
 (* ------------------------------------------------------------------ *)
 
 Definition ascii_minus : Z := 45.   (** '-' *)
 Definition ascii_space : Z := 32.   (** ' ' *)
+Definition ascii_star  : Z := 42.   (** '*' *)
 
 (** True iff [c] is an ASCII decimal digit. *)
 Definition is_digit (c : Z) : bool := (48 <=? c) && (c <=? 57).
@@ -312,6 +333,22 @@ Definition parse_int (cs : list Z) : option (Z * list Z) :=
            then let (n, tail) := scan_digits cs 0 (length cs) in
                 Some (n, tail)
            else None
+  end.
+
+(** Parse an inline BSP submodel reference of the form ["*N"].
+    Returns [Some N] iff the string begins with ['*'], the remainder
+    parses as a decimal integer, the parse consumes the full string,
+    and [N] is non-negative. *)
+Definition parse_inline_model_ref (cs : list Z) : option Z :=
+  match cs with
+  | c :: rest =>
+      if c =? ascii_star then
+        match parse_int rest with
+        | Some (n, []) => if n <? 0 then None else Some n
+        | _            => None
+        end
+      else None
+  | [] => None
   end.
 
 (* ------------------------------------------------------------------ *)
@@ -356,4 +393,19 @@ Proof. vm_compute. reflexivity. Qed.
 
 (** Negative integer. *)
 Lemma parse_int_neg_1 : parse_int [45; 49] = Some (-1, []).
+Proof. vm_compute. reflexivity. Qed.
+
+(** A well-formed inline model reference parses successfully. *)
+Lemma parse_inline_model_ref_pos :
+  parse_inline_model_ref [42; 49; 50] = Some 12.
+Proof. vm_compute. reflexivity. Qed.
+
+(** Negative inline model references are rejected. *)
+Lemma parse_inline_model_ref_neg :
+  parse_inline_model_ref [42; 45; 49] = None.
+Proof. vm_compute. reflexivity. Qed.
+
+(** Missing the leading ['*'] is not a valid inline model reference. *)
+Lemma parse_inline_model_ref_missing_star :
+  parse_inline_model_ref [49; 50] = None.
 Proof. vm_compute. reflexivity. Qed.

--- a/theories/GameState.v
+++ b/theories/GameState.v
@@ -405,16 +405,20 @@ Definition parse_origin_vec3 (cs : list Z) : option vec3 :=
               | _ => None
               end
           end
-      | _ => None
-      end
+       | _ => None
+       end
+   end.
+
+(** True iff entity [e] has the given classname. *)
+Definition entity_classname_eqb (e : bsp_entity) (classname : list Z) : bool :=
+  match entity_get_val e key_classname with
+  | Some v => list_Z_eqb v classname
+  | None   => false
   end.
 
 (** True iff entity [e] has classname [info_player_deathmatch]. *)
 Definition is_spawn_entity (e : bsp_entity) : bool :=
-  match entity_get_val e key_classname with
-  | Some v => list_Z_eqb v val_info_player_deathmatch
-  | None   => false
-  end.
+  entity_classname_eqb e val_info_player_deathmatch.
 
 (** Extract the world-space origin from a spawn entity.
     Returns [None] if no [origin] key is present or the value is
@@ -436,6 +440,74 @@ Definition spawn_yaw_of_entity (e : bsp_entity) : Q :=
       end
   | None => 0
   end.
+
+(* ------------------------------------------------------------------ *)
+(** ** Trigger metadata extraction from entity data                     *)
+(* ------------------------------------------------------------------ *)
+
+Record trigger_push_metadata : Type := mk_trigger_push_metadata
+  { tpm_model_index : Z
+  ; tpm_target_name : list Z
+  }.
+
+Record target_position_metadata : Type := mk_target_position_metadata
+  { tpos_target_name : list Z
+  ; tpos_origin      : vec3
+  }.
+
+(** True iff entity [e] has classname [trigger_push]. *)
+Definition is_trigger_push_entity (e : bsp_entity) : bool :=
+  entity_classname_eqb e val_trigger_push.
+
+(** True iff entity [e] has classname [target_position]. *)
+Definition is_target_position_entity (e : bsp_entity) : bool :=
+  entity_classname_eqb e val_target_position.
+
+(** Extract the inline BSP submodel index from an entity's [model] key. *)
+Definition entity_model_index (e : bsp_entity) : option Z :=
+  match entity_get_val e key_model with
+  | Some v => parse_inline_model_ref v
+  | None   => None
+  end.
+
+(** Extract the target name an entity points at via its [target] key. *)
+Definition entity_target_name (e : bsp_entity) : option (list Z) :=
+  entity_get_val e key_target.
+
+(** Extract the name by which another entity can target this one. *)
+Definition entity_targetname (e : bsp_entity) : option (list Z) :=
+  entity_get_val e key_targetname.
+
+(** Extract a [target_position] origin from entity data. *)
+Definition target_position_origin_of_entity (e : bsp_entity) : option vec3 :=
+  match entity_get_val e key_origin with
+  | Some v => parse_origin_vec3 v
+  | None   => None
+  end.
+
+(** Parse the metadata v1 needs from a [trigger_push] entity.
+    The trigger must carry both an inline [model] reference and a
+    [target] name so later world-building code can resolve it. *)
+Definition parse_trigger_push_metadata (e : bsp_entity)
+    : option trigger_push_metadata :=
+  if is_trigger_push_entity e then
+    match entity_model_index e, entity_target_name e with
+    | Some model_index, Some target_name =>
+        Some (mk_trigger_push_metadata model_index target_name)
+    | _, _ => None
+    end
+  else None.
+
+(** Parse the metadata v1 needs from a [target_position] entity. *)
+Definition parse_target_position_metadata (e : bsp_entity)
+    : option target_position_metadata :=
+  if is_target_position_entity e then
+    match entity_targetname e, target_position_origin_of_entity e with
+    | Some target_name, Some origin =>
+        Some (mk_target_position_metadata target_name origin)
+    | _, _ => None
+    end
+  else None.
 
 (** [select_spawn_point entities] returns the position and yaw of the
     first [info_player_deathmatch] entity that has a parseable [origin].
@@ -644,6 +716,33 @@ Proof. vm_compute. reflexivity. Qed.
 Lemma parse_origin_neg_example :
   parse_origin_vec3 [45; 52; 56; 32; 49; 50; 56; 32; 45; 56] =
     Some (mk_vec3 (inject_Z (-48)) (inject_Z 128) (inject_Z (-8))).
+Proof. vm_compute. reflexivity. Qed.
+
+Lemma parse_trigger_push_metadata_example :
+  parse_trigger_push_metadata
+    [ (key_classname, val_trigger_push)
+    ; (key_model, [42; 51])
+    ; (key_target, [112; 97; 100; 49])
+    ] =
+  Some (mk_trigger_push_metadata 3 [112; 97; 100; 49]).
+Proof. vm_compute. reflexivity. Qed.
+
+Lemma parse_trigger_push_metadata_requires_target :
+  parse_trigger_push_metadata
+    [ (key_classname, val_trigger_push)
+    ; (key_model, [42; 51])
+    ] = None.
+Proof. vm_compute. reflexivity. Qed.
+
+Lemma parse_target_position_metadata_example :
+  parse_target_position_metadata
+    [ (key_classname, val_target_position)
+    ; (key_targetname, [112; 97; 100; 49])
+    ; (key_origin, [49; 50; 56; 32; 48; 32; 50; 53; 54])
+    ] =
+  Some (mk_target_position_metadata
+          [112; 97; 100; 49]
+          (mk_vec3 128 0 256)).
 Proof. vm_compute. reflexivity. Qed.
 
 (** An empty entity list has no spawn points. *)

--- a/theories/GameState.v
+++ b/theories/GameState.v
@@ -53,6 +53,13 @@ Definition vec3_add (a b : vec3) : vec3 :=
     (v3_y a + v3_y b)
     (v3_z a + v3_z b).
 
+(** Vector subtraction. *)
+Definition vec3_sub (a b : vec3) : vec3 :=
+  mk_vec3
+    (v3_x a - v3_x b)
+    (v3_y a - v3_y b)
+    (v3_z a - v3_z b).
+
 (** Scalar multiplication of a vector. *)
 Definition vec3_scale (k : Q) (v : vec3) : vec3 :=
   mk_vec3
@@ -144,10 +151,17 @@ Record collision_brush_input : Type := mk_collision_brush_input
 Record collision_brush_side_input : Type := mk_collision_brush_side_input
   { cbsi_plane_index : Z }.
 
+(** Minimal BSP submodel data needed for trigger volumes. *)
+Record collision_model_input : Type := mk_collision_model_input
+  { cmi_first_brush : Z
+  ; cmi_num_brushes : Z
+  }.
+
 (** Static BSP collision data provided by the browser at world load. *)
 Record collision_world_input : Type := mk_collision_world_input
   { cwi_planes      : list collision_plane_input
   ; cwi_textures    : list collision_texture_input
+  ; cwi_models      : list collision_model_input
   ; cwi_brushes     : list collision_brush_input
   ; cwi_brush_sides : list collision_brush_side_input
   }.
@@ -219,7 +233,7 @@ Definition visible_face_indices
   visible_face_indices_aux faces textures 0.
 
 Definition collision_world_empty : collision_world_input :=
-  mk_collision_world_input [] [] [] [].
+  mk_collision_world_input [] [] [] [] [].
 
 Definition contents_solid : Z := 1.
 
@@ -664,6 +678,7 @@ Definition player_radius : Q := 16.
 Definition ground_probe_distance : Q := 1.
 Definition gravity_accel : Q := 800.
 Definition jump_speed : Q := 270.
+Definition trigger_push_travel_time : Q := 1.
 Definition collision_sweep_iterations : nat := 8%nat.
 Definition collision_motion_substeps : nat := 16%nat.
 Definition collision_motion_substep_scale : Q := (1 # 16)%Q.
@@ -705,6 +720,19 @@ Definition point_collides_brushb
     end
   else false.
 
+Definition point_collides_brush_geometryb
+    (world : collision_world_input) (pos : vec3) (br : collision_brush_input) : bool :=
+  match Z.max 0 (cbi_num_sides br) with
+  | 0 => false
+  | n =>
+      point_collides_brush_aux
+        (cwi_planes world)
+        (cwi_brush_sides world)
+        pos
+        (cbi_first_side br)
+        (Z.to_nat n)
+  end.
+
 Fixpoint point_collides_world_aux
     (world : collision_world_input) (pos : vec3)
     (brushes : list collision_brush_input) : bool :=
@@ -718,6 +746,69 @@ Fixpoint point_collides_world_aux
 Definition point_collides_worldb
     (world : collision_world_input) (pos : vec3) : bool :=
   point_collides_world_aux world pos (cwi_brushes world).
+
+Fixpoint point_collides_model_brushes_aux
+    (world : collision_world_input) (pos : vec3)
+    (brush_index : Z) (fuel : nat) : bool :=
+  match fuel with
+  | O => false
+  | S fuel' =>
+      match nth_z (cwi_brushes world) brush_index with
+      | None => false
+      | Some br =>
+          if point_collides_brush_geometryb world pos br
+          then true
+          else point_collides_model_brushes_aux world pos (brush_index + 1) fuel'
+      end
+  end.
+
+Definition point_collides_modelb
+    (world : collision_world_input) (pos : vec3) (model : collision_model_input) : bool :=
+  match Z.max 0 (cmi_num_brushes model) with
+  | 0 => false
+  | n =>
+      point_collides_model_brushes_aux
+        world pos (cmi_first_brush model) (Z.to_nat n)
+  end.
+
+Definition entity_inside_trigger_modelb
+    (world : collision_world_input) (pos : vec3) (es : entity_state) : bool :=
+  match nth_z (cwi_models world) (es_model_index es) with
+  | Some model => point_collides_modelb world pos model
+  | None => false
+  end.
+
+Definition trigger_push_velocity
+    (pos target_origin : vec3) : vec3 :=
+  let delta := vec3_sub target_origin pos in
+  let t := trigger_push_travel_time in
+  mk_vec3
+    (v3_x delta / t)
+    (v3_y delta / t)
+    ((v3_z delta / t) + gravity_accel * t / 2)%Q.
+
+Fixpoint apply_trigger_pushes
+    (world : collision_world_input) (pos : vec3)
+    (entities : list entity_state)
+    : option vec3 * list entity_state :=
+  match entities with
+  | [] => (None, [])
+  | es :: rest =>
+      let inside := entity_inside_trigger_modelb world pos es in
+      let fired := es_active es && inside in
+      let updated :=
+        mk_entity_state
+          (es_entity_index es)
+          (es_model_index es)
+          (es_origin es)
+          (negb inside) in
+      let '(rest_impulse, rest_entities) := apply_trigger_pushes world pos rest in
+      let impulse :=
+        if fired
+        then Some (trigger_push_velocity pos (es_origin es))
+        else rest_impulse in
+      (impulse, updated :: rest_entities)
+  end.
 
 Fixpoint sweep_to_contact
     (world : collision_world_input) (lo hi : vec3) (fuel : nat) : vec3 :=
@@ -1110,19 +1201,31 @@ Definition step_world_in_world
   let '(position, vertical_blocked) :=
     resolve_motion_substeps world horizontal_pos vertical_delta in
   let landed := vertical_blocked && qleb desired_vel_z 0 in
-  let on_ground := landed || grounded_by_worldb world position in
-  let velocity :=
+  let base_on_ground := landed || grounded_by_worldb world position in
+  let base_velocity :=
     mk_vec3
       (if horizontal_blocked then 0 else v3_x desired_planar)
       (if horizontal_blocked then 0 else v3_y desired_planar)
       (if vertical_blocked then 0 else desired_vel_z) in
+  let '(trigger_impulse, entities) :=
+    apply_trigger_pushes world position (gs_entities gs) in
+  let velocity :=
+    match trigger_impulse with
+    | Some impulse => impulse
+    | None => base_velocity
+    end in
+  let on_ground :=
+    match trigger_impulse with
+    | Some _ => false
+    | None => base_on_ground
+    end in
   mk_game_state
     position
     velocity
     yaw
     pitch
     on_ground
-    (gs_entities gs)
+    entities
     (gs_tick gs + 1).
 
 (** Bridge-facing word-level entry point for per-frame stepping.
@@ -1310,10 +1413,11 @@ Definition sample_floor_world : collision_world_input :=
     ; mk_collision_plane_input (-1)   0    0 1024
     ; mk_collision_plane_input   0    1    0 1024
     ; mk_collision_plane_input   0  (-1)   0 1024
-    ; mk_collision_plane_input   0    0    1    0
-    ; mk_collision_plane_input   0    0  (-1)  64
-    ]
+     ; mk_collision_plane_input   0    0    1    0
+     ; mk_collision_plane_input   0    0  (-1)  64
+     ]
     [sample_solid_texture]
+    []
     [mk_collision_brush_input 0 6 0]
     [ mk_collision_brush_side_input 0
     ; mk_collision_brush_side_input 1
@@ -1329,10 +1433,31 @@ Definition sample_wall_world : collision_world_input :=
     ; mk_collision_plane_input (-1)   0    0  (-32)
     ; mk_collision_plane_input   0    1    0 1024
     ; mk_collision_plane_input   0  (-1)   0 1024
-    ; mk_collision_plane_input   0    0    1 1024
-    ; mk_collision_plane_input   0    0  (-1) 1024
-    ]
+     ; mk_collision_plane_input   0    0    1 1024
+     ; mk_collision_plane_input   0    0  (-1) 1024
+     ]
     [sample_solid_texture]
+    []
+    [mk_collision_brush_input 0 6 0]
+    [ mk_collision_brush_side_input 0
+    ; mk_collision_brush_side_input 1
+    ; mk_collision_brush_side_input 2
+    ; mk_collision_brush_side_input 3
+    ; mk_collision_brush_side_input 4
+    ; mk_collision_brush_side_input 5
+    ].
+
+Definition sample_trigger_world : collision_world_input :=
+  mk_collision_world_input
+    [ mk_collision_plane_input   1    0    0   32
+    ; mk_collision_plane_input (-1)   0    0   32
+    ; mk_collision_plane_input   0    1    0   32
+    ; mk_collision_plane_input   0  (-1)   0   32
+    ; mk_collision_plane_input   0    0    1    0
+    ; mk_collision_plane_input   0    0  (-1)  64
+    ]
+    []
+    [mk_collision_model_input 0 1]
     [mk_collision_brush_input 0 6 0]
     [ mk_collision_brush_side_input 0
     ; mk_collision_brush_side_input 1
@@ -1374,3 +1499,23 @@ Proof. vm_compute. reflexivity. Qed.
 Lemma point_collides_worldb_sample_wall :
   point_collides_worldb sample_wall_world (mk_vec3 16 0 128) = true.
 Proof. vm_compute. reflexivity. Qed.
+
+Lemma point_collides_modelb_sample_trigger :
+  point_collides_modelb sample_trigger_world (mk_vec3 0 0 16)
+    (mk_collision_model_input 0 1) = true.
+Proof. vm_compute. reflexivity. Qed.
+
+Lemma step_world_in_world_trigger_push_example :
+  let stepped :=
+    step_world_in_world sample_trigger_world
+      (mk_game_state
+         (mk_vec3 0 0 16)
+         vec3_zero
+         0 0 false
+         [mk_entity_state 0 0 (mk_vec3 0 0 256) true]
+         0)
+      input_snapshot_zero in
+  v3_z (gs_velocity stepped) == 640 /\
+  gs_on_ground stepped = false /\
+  gs_entities stepped = [mk_entity_state 0 0 (mk_vec3 0 0 256) false].
+Proof. vm_compute. repeat split; reflexivity. Qed.

--- a/theories/GameState.v
+++ b/theories/GameState.v
@@ -964,6 +964,24 @@ Proof.
     reflexivity.
 Qed.
 
+(** When a spawn point is found, the initial position comes from it. *)
+Lemma game_state_from_entities_position : forall entities pos yaw,
+  select_spawn_point entities = Some (pos, yaw) ->
+  gs_position (game_state_from_entities entities) = pos.
+Proof.
+  intros entities pos yaw Hspawn.
+  unfold game_state_from_entities. rewrite Hspawn. reflexivity.
+Qed.
+
+(** When a spawn point is found, the initial yaw comes from it. *)
+Lemma game_state_from_entities_yaw : forall entities pos yaw,
+  select_spawn_point entities = Some (pos, yaw) ->
+  gs_yaw (game_state_from_entities entities) = yaw.
+Proof.
+  intros entities pos yaw Hspawn.
+  unfold game_state_from_entities. rewrite Hspawn. reflexivity.
+Qed.
+
 (** The bridge helper always yields the five serialized camera values. *)
 Lemma initial_camera_words_from_entities_length : forall entities,
   length (initial_camera_words_from_entities entities) = 10%nat.
@@ -1470,21 +1488,47 @@ Proof.
   intro p. apply Z.leb_gt. apply Pos2Z.is_pos.
 Qed.
 
-(** [game_state_to_words] round-trips through [game_state_from_words]
-    for states with an empty entity list. *)
+(** [entity_state_to_words] round-trips through [entity_state_from_words]
+    with any trailing payload preserved. *)
+Lemma entity_state_roundtrip : forall es tail,
+  entity_state_from_words (entity_state_to_words es ++ tail) =
+  Some (es, tail).
+Proof.
+  intros [entity_index model_index [ox oy oz] active] tail.
+  destruct ox as [oxn oxd], oy as [oyn oyd], oz as [ozn ozd].
+  unfold entity_state_to_words, entity_state_from_words, q_words. simpl.
+  destruct tail as [| z tail']; repeat rewrite Z_pos_leb_0; simpl;
+    destruct active; reflexivity.
+Qed.
+
+Lemma entity_states_roundtrip : forall entities,
+  entity_states_from_words_aux (length entities) (entity_states_to_words entities) =
+  Some (entities, []).
+Proof.
+  induction entities as [| es rest IH].
+  - reflexivity.
+  - cbn [length entity_states_from_words_aux entity_states_to_words].
+    rewrite entity_state_roundtrip.
+    rewrite IH. reflexivity.
+Qed.
+
+(** [game_state_to_words] round-trips through [game_state_from_words]. *)
 Lemma game_state_roundtrip : forall gs,
-  gs_entities gs = [] ->
   game_state_from_words (game_state_to_words gs) = Some gs.
 Proof.
-  intros gs Hnil.
+  intros gs.
   destruct gs as [[px py pz] [vx vy vz] yaw pitch grounded ents tick].
-  simpl in Hnil. subst ents.
   (* Destruct each Q into num/den so Z.to_pos (Z.pos den) = den by reflexivity. *)
   destruct px as [pxn pxd], py as [pyn pyd], pz as [pzn pzd].
   destruct vx as [vxn vxd], vy as [vyn vyd], vz as [vzn vzd].
   destruct yaw as [yn yd], pitch as [pn pd].
   unfold game_state_to_words, game_state_from_words, q_words. simpl.
   repeat rewrite Z_pos_leb_0. simpl.
+  assert ((Z.of_nat (length ents) <? 0) = false) as Hcount.
+  { apply Z.ltb_ge. lia. }
+  rewrite Hcount. simpl.
+  rewrite Nat2Z.id.
+  rewrite entity_states_roundtrip.
   destruct grounded; reflexivity.
 Qed.
 
@@ -1603,6 +1647,50 @@ Lemma point_collides_modelb_sample_trigger :
   point_collides_modelb sample_trigger_world (mk_vec3 0 0 16)
     (mk_collision_model_input 0 1) = true.
 Proof. vm_compute. reflexivity. Qed.
+
+Lemma apply_trigger_pushes_single_outside : forall world pos es,
+  entity_inside_trigger_modelb world pos es = false ->
+  apply_trigger_pushes world pos [es] =
+  (None,
+   [mk_entity_state
+      (es_entity_index es)
+      (es_model_index es)
+      (es_origin es)
+      true]).
+Proof.
+  intros world pos [entity_index model_index [ox oy oz] active] Hinside.
+  simpl in *. rewrite Hinside. destruct active; reflexivity.
+Qed.
+
+Lemma apply_trigger_pushes_single_inside_active : forall world pos es,
+  entity_inside_trigger_modelb world pos es = true ->
+  es_active es = true ->
+  apply_trigger_pushes world pos [es] =
+  (Some (trigger_push_velocity pos (es_origin es)),
+   [mk_entity_state
+      (es_entity_index es)
+      (es_model_index es)
+      (es_origin es)
+      false]).
+Proof.
+  intros world pos [entity_index model_index [ox oy oz] active] Hinside Hactive.
+  simpl in *. subst active. rewrite Hinside. reflexivity.
+Qed.
+
+Lemma apply_trigger_pushes_single_inside_inactive : forall world pos es,
+  entity_inside_trigger_modelb world pos es = true ->
+  es_active es = false ->
+  apply_trigger_pushes world pos [es] =
+  (None,
+   [mk_entity_state
+      (es_entity_index es)
+      (es_model_index es)
+      (es_origin es)
+      false]).
+Proof.
+  intros world pos [entity_index model_index [ox oy oz] active] Hinside Hactive.
+  simpl in *. subst active. rewrite Hinside. reflexivity.
+Qed.
 
 Lemma step_world_in_world_trigger_push_example :
   let stepped :=

--- a/theories/GameState.v
+++ b/theories/GameState.v
@@ -1034,16 +1034,30 @@ Qed.
 (** ** World-state serialization and frame stepping                    *)
 (* ------------------------------------------------------------------ *)
 
+(** Number of [Z] words produced per serialized [entity_state]. *)
+Definition entity_state_words_count : nat := 9.
+
 (** Number of [Z] words produced by [game_state_to_words] for a
     game state with an empty entity list. *)
-Definition game_state_words_count : nat := 18.
+Definition game_state_words_count : nat := 19.
+
+Definition entity_state_to_words (es : entity_state) : list Z :=
+  [es_entity_index es; es_model_index es] ++
+  q_words (v3_x (es_origin es)) ++
+  q_words (v3_y (es_origin es)) ++
+  q_words (v3_z (es_origin es)) ++
+  [if es_active es then 1 else 0].
+
+Fixpoint entity_states_to_words (entities : list entity_state) : list Z :=
+  match entities with
+  | [] => []
+  | es :: rest => entity_state_to_words es ++ entity_states_to_words rest
+  end.
 
 (** Serialize a [game_state] to a flat [list Z] suitable for
-    round-tripping through the JS bridge.  The entity list is
-    omitted; v1 entities carry no per-step dynamic state that
-    needs crossing the bridge boundary.
+    round-tripping through the JS bridge.
 
-    Word layout (18 entries):
+    Word layout (19 + 9 * entity_count entries):
     <<
        0  px_num   1  px_den
        2  py_num   3  py_den
@@ -1055,6 +1069,8 @@ Definition game_state_words_count : nat := 18.
       14 pch_num  15 pch_den
       16 on_ground          (0 = airborne, 1 = grounded)
       17 tick
+      18 entity_count
+      19... serialized entity states
     >>
 *)
 Definition game_state_to_words (gs : game_state) : list Z :=
@@ -1067,34 +1083,92 @@ Definition game_state_to_words (gs : game_state) : list Z :=
   q_words (gs_yaw gs) ++
   q_words (gs_pitch gs) ++
   [(if gs_on_ground gs then 1 else 0)] ++
-  [gs_tick gs].
+  [gs_tick gs] ++
+  [Z.of_nat (length (gs_entities gs))] ++
+  entity_states_to_words (gs_entities gs).
+
+Definition entity_state_from_words (ws : list Z)
+    : option (entity_state * list Z) :=
+  match ws with
+  | [entity_index; model_index;
+     ox_n; ox_d; oy_n; oy_d; oz_n; oz_d;
+     active] =>
+      if (ox_d <=? 0) || (oy_d <=? 0) || (oz_d <=? 0)
+      then None
+      else
+        Some
+          ( mk_entity_state
+              entity_index
+              model_index
+              (mk_vec3 (Qmake ox_n (Z.to_pos ox_d))
+                       (Qmake oy_n (Z.to_pos oy_d))
+                       (Qmake oz_n (Z.to_pos oz_d)))
+              (negb (active =? 0))
+          , []
+          )
+  | entity_index :: model_index ::
+    ox_n :: ox_d :: oy_n :: oy_d :: oz_n :: oz_d :: active :: rest =>
+      if (ox_d <=? 0) || (oy_d <=? 0) || (oz_d <=? 0)
+      then None
+      else
+        Some
+          ( mk_entity_state
+              entity_index
+              model_index
+              (mk_vec3 (Qmake ox_n (Z.to_pos ox_d))
+                       (Qmake oy_n (Z.to_pos oy_d))
+                       (Qmake oz_n (Z.to_pos oz_d)))
+              (negb (active =? 0))
+          , rest
+          )
+  | _ => None
+  end.
+
+Fixpoint entity_states_from_words_aux (count : nat) (ws : list Z)
+    : option (list entity_state * list Z) :=
+  match count with
+  | O => Some ([], ws)
+  | S count' =>
+      match entity_state_from_words ws with
+      | Some (es, rest) =>
+          match entity_states_from_words_aux count' rest with
+          | Some (entities, tail) => Some (es :: entities, tail)
+          | None => None
+          end
+      | None => None
+      end
+  end.
 
 (** Reconstruct a [game_state] from the word list produced by
     [game_state_to_words].  Returns [None] on a malformed list or
     any zero/negative denominator. *)
 Definition game_state_from_words (ws : list Z) : option game_state :=
   match ws with
-  | [px_n; px_d; py_n; py_d; pz_n; pz_d;
-     vx_n; vx_d; vy_n; vy_d; vz_n; vz_d;
-     yaw_n; yaw_d; pitch_n; pitch_d;
-     on_ground; tick] =>
+  | px_n :: px_d :: py_n :: py_d :: pz_n :: pz_d ::
+    vx_n :: vx_d :: vy_n :: vy_d :: vz_n :: vz_d ::
+    yaw_n :: yaw_d :: pitch_n :: pitch_d ::
+    on_ground :: tick :: entity_count :: entity_words =>
       if (px_d <=? 0) || (py_d <=? 0) || (pz_d <=? 0) ||
-         (vx_d <=? 0) || (vy_d <=? 0) || (vz_d <=? 0) ||
-         (yaw_d <=? 0) || (pitch_d <=? 0)
+          (vx_d <=? 0) || (vy_d <=? 0) || (vz_d <=? 0) ||
+          (yaw_d <=? 0) || (pitch_d <=? 0) || (entity_count <? 0)
       then None
       else
-        Some (mk_game_state
-          (mk_vec3 (Qmake px_n (Z.to_pos px_d))
-                   (Qmake py_n (Z.to_pos py_d))
-                   (Qmake pz_n (Z.to_pos pz_d)))
-          (mk_vec3 (Qmake vx_n (Z.to_pos vx_d))
-                   (Qmake vy_n (Z.to_pos vy_d))
-                   (Qmake vz_n (Z.to_pos vz_d)))
-          (Qmake yaw_n   (Z.to_pos yaw_d))
-          (Qmake pitch_n (Z.to_pos pitch_d))
-          (negb (on_ground =? 0))
-          []
-          tick)
+        match entity_states_from_words_aux (Z.to_nat entity_count) entity_words with
+        | Some (entities, []) =>
+            Some (mk_game_state
+              (mk_vec3 (Qmake px_n (Z.to_pos px_d))
+                       (Qmake py_n (Z.to_pos py_d))
+                       (Qmake pz_n (Z.to_pos pz_d)))
+              (mk_vec3 (Qmake vx_n (Z.to_pos vx_d))
+                       (Qmake vy_n (Z.to_pos vy_d))
+                       (Qmake vz_n (Z.to_pos vz_d)))
+              (Qmake yaw_n   (Z.to_pos yaw_d))
+              (Qmake pitch_n (Z.to_pos pitch_d))
+              (negb (on_ground =? 0))
+              entities
+              tick)
+        | _ => None
+        end
   | _ => None
   end.
 
@@ -1260,11 +1334,34 @@ Definition initial_game_state_words_from_entities
 (** ** Correctness lemmas for world stepping                           *)
 (* ------------------------------------------------------------------ *)
 
-Lemma game_state_to_words_length : forall gs,
-  length (game_state_to_words gs) = game_state_words_count.
+Lemma entity_state_to_words_length : forall es,
+  length (entity_state_to_words es) = entity_state_words_count.
 Proof.
-  intros gs. unfold game_state_to_words, q_words, game_state_words_count.
+  intros es. unfold entity_state_to_words, q_words, entity_state_words_count.
   repeat rewrite length_app. simpl. reflexivity.
+Qed.
+
+Lemma entity_states_to_words_length : forall entities,
+  length (entity_states_to_words entities) =
+  (entity_state_words_count * length entities)%nat.
+Proof.
+  induction entities as [| es rest IH]; simpl.
+  - reflexivity.
+  - destruct es as [entity_index model_index origin active].
+    destruct origin as [ox oy oz].
+    unfold entity_state_words_count in *. simpl in *.
+    rewrite IH. lia.
+Qed.
+
+Lemma game_state_to_words_length : forall gs,
+  length (game_state_to_words gs) =
+  (game_state_words_count +
+   entity_state_words_count * length (gs_entities gs))%nat.
+Proof.
+  intros [[px py pz] [vx vy vz] yaw pitch grounded entities tick].
+  unfold game_state_to_words, q_words, game_state_words_count, entity_state_words_count.
+  simpl.
+  rewrite entity_states_to_words_length. reflexivity.
 Qed.
 
 (** Stepping integrates position from the per-frame velocity. *)
@@ -1391,10 +1488,12 @@ Proof.
   destruct grounded; reflexivity.
 Qed.
 
-(** Serialized word count matches [game_state_words_count]. *)
+(** Serialized word count includes the per-entity payload. *)
 Lemma initial_game_state_words_from_entities_length : forall entities,
   length (initial_game_state_words_from_entities entities) =
-  game_state_words_count.
+  (game_state_words_count +
+   entity_state_words_count *
+   length (gs_entities (game_state_from_entities entities)))%nat.
 Proof.
   intros entities. unfold initial_game_state_words_from_entities.
   apply game_state_to_words_length.

--- a/theories/GameState.v
+++ b/theories/GameState.v
@@ -92,7 +92,8 @@ Definition input_snapshot_zero : input_snapshot :=
     For v1, the primary entity type is [trigger_push] (jump pads). *)
 Record entity_state : Type := mk_entity_state
   { es_entity_index : Z       (** index into [bf_entities] *)
-  ; es_origin       : vec3    (** world-space position *)
+  ; es_model_index  : Z       (** inline BSP submodel index *)
+  ; es_origin       : vec3    (** resolved world-space target/origin *)
   ; es_active       : bool    (** whether the trigger is armed *)
   }.
 
@@ -455,6 +456,10 @@ Record target_position_metadata : Type := mk_target_position_metadata
   ; tpos_origin      : vec3
   }.
 
+Definition target_position_name_eqb
+    (target : target_position_metadata) (name : list Z) : bool :=
+  list_Z_eqb (tpos_target_name target) name.
+
 (** True iff entity [e] has classname [trigger_push]. *)
 Definition is_trigger_push_entity (e : bsp_entity) : bool :=
   entity_classname_eqb e val_trigger_push.
@@ -509,6 +514,61 @@ Definition parse_target_position_metadata (e : bsp_entity)
     end
   else None.
 
+Fixpoint collect_target_positions
+    (entities : list bsp_entity) : list target_position_metadata :=
+  match entities with
+  | [] => []
+  | e :: rest =>
+      match parse_target_position_metadata e with
+      | Some target => target :: collect_target_positions rest
+      | None        => collect_target_positions rest
+      end
+  end.
+
+Fixpoint find_target_position_origin
+    (targets : list target_position_metadata) (name : list Z) : option vec3 :=
+  match targets with
+  | [] => None
+  | target :: rest =>
+      if target_position_name_eqb target name
+      then Some (tpos_origin target)
+      else find_target_position_origin rest name
+  end.
+
+Fixpoint initial_trigger_states_from_entities_aux
+    (entities : list bsp_entity)
+    (targets : list target_position_metadata)
+    (entity_index : Z) : list entity_state :=
+  match entities with
+  | [] => []
+  | e :: rest =>
+      let rest_states :=
+        initial_trigger_states_from_entities_aux rest targets (entity_index + 1) in
+      match parse_trigger_push_metadata e with
+      | Some trigger =>
+          match find_target_position_origin targets (tpm_target_name trigger) with
+          | Some origin =>
+              mk_entity_state
+                entity_index
+                (tpm_model_index trigger)
+                origin
+                true :: rest_states
+          | None => rest_states
+          end
+      | None => rest_states
+      end
+  end.
+
+(** Resolve the initial trigger/jump-pad state directly from the BSP
+    entity list by pairing [trigger_push] entities with the
+    [target_position] entities they reference. *)
+Definition initial_trigger_states_from_entities
+    (entities : list bsp_entity) : list entity_state :=
+  initial_trigger_states_from_entities_aux
+    entities
+    (collect_target_positions entities)
+    0.
+
 (** [select_spawn_point entities] returns the position and yaw of the
     first [info_player_deathmatch] entity that has a parseable [origin].
     Returns [None] if no such entity exists. *)
@@ -530,9 +590,10 @@ Fixpoint select_spawn_point (entities : list bsp_entity)
     [entities]; if none exists, falls back to [game_state_init]. *)
 Definition game_state_from_entities (entities : list bsp_entity)
     : game_state :=
+  let trigger_states := initial_trigger_states_from_entities entities in
   match select_spawn_point entities with
-  | Some (pos, yaw) => mk_game_state pos vec3_zero yaw 0 true [] 0
-  | None            => game_state_init
+  | Some (pos, yaw) => mk_game_state pos vec3_zero yaw 0 true trigger_states 0
+  | None            => mk_game_state vec3_zero vec3_zero 0 0 true trigger_states 0
   end.
 
 (** End-to-end helper for the browser bridge: derive the initial camera
@@ -745,6 +806,27 @@ Lemma parse_target_position_metadata_example :
           (mk_vec3 128 0 256)).
 Proof. vm_compute. reflexivity. Qed.
 
+Lemma find_target_position_origin_example :
+  find_target_position_origin
+    [ mk_target_position_metadata [112; 97; 100; 49] (mk_vec3 128 0 256) ]
+    [112; 97; 100; 49] =
+  Some (mk_vec3 128 0 256).
+Proof. vm_compute. reflexivity. Qed.
+
+Lemma initial_trigger_states_from_entities_example :
+  initial_trigger_states_from_entities
+    [ ( (key_classname, val_trigger_push)
+        :: (key_model, [42; 51])
+        :: (key_target, [112; 97; 100; 49])
+        :: nil )
+    ; ( (key_classname, val_target_position)
+        :: (key_targetname, [112; 97; 100; 49])
+        :: (key_origin, [49; 50; 56; 32; 48; 32; 50; 53; 54])
+        :: nil )
+    ] =
+  [mk_entity_state 0 3 (mk_vec3 128 0 256) true].
+Proof. vm_compute. reflexivity. Qed.
+
 (** An empty entity list has no spawn points. *)
 Lemma select_spawn_point_nil :
   select_spawn_point [] = None.
@@ -776,6 +858,15 @@ Qed.
 (** A spawn-derived state starts grounded. *)
 Lemma game_state_from_entities_grounded : forall entities,
   gs_on_ground (game_state_from_entities entities) = true.
+Proof.
+  intros entities. unfold game_state_from_entities.
+  destruct (select_spawn_point entities) as [[[px py pz] yaw] |];
+    reflexivity.
+Qed.
+
+Lemma game_state_from_entities_entities : forall entities,
+  gs_entities (game_state_from_entities entities) =
+  initial_trigger_states_from_entities entities.
 Proof.
   intros entities. unfold game_state_from_entities.
   destruct (select_spawn_point entities) as [[[px py pz] yaw] |];


### PR DESCRIPTION
Fixes #26.

Ports the q3dm1 jump-pad gameplay path into Rocq end to end: spawn selection, trigger metadata, initial trigger state, and `trigger_push` impulses now live in authoritative world stepping. The remaining work is to thread the richer restart and trigger world data through the JS bridge and lock the behavior down with proofs for the final spawn and trigger semantics.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (6)</summary>

- [x] Wire restart and trigger world data through the JS bridge <!-- type:spec -->
- [x] Add proofs for q3dm1 spawn and trigger behavior <!-- type:spec -->
- [x] Apply trigger_push impulses in Rocq world stepping <!-- type:spec -->
- [x] Build initial spawn and trigger state from BSP entities <!-- type:spec -->
- [x] Parse BSP trigger model and target metadata in Rocq <!-- type:spec -->
- [x] Document q3dm1 entity scope and deferrals <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->