### PR TITLE
Make the demo level playable (closes #16)

### DIFF
--- a/ASSETS.md
+++ b/ASSETS.md
@@ -64,7 +64,10 @@ Additional relevant prohibitions:
 committed to this repository or to the `docs/` build output that Pages serves.
 Any build or CI step that would publish extracted asset files to Pages would
 constitute redistribution of individual extracted files and/or public display,
-both of which the EULA prohibits.
+both of which the EULA prohibits.  The public Pages deployment may still host
+the HTML/CSS/JS/Rocq shell itself, but it must treat q3dm1 asset loading as a
+local, user-supplied step rather than shipping a publicly playable copy of the
+map.
 
 ### Approved approach for local development and CI
 
@@ -77,6 +80,10 @@ Users must supply their own copy of the demo distribution.  A future
 3. Serve or incorporate those files into the local build.
 
 The extracted files must never be committed, pushed, or deployed.
+
+In practice this means the public site can only demonstrate the shell, theory
+loading, and "bring your own demo assets" flow.  Any actually playable q3dm1
+session has to come from a local build fed by the user's own demo package.
 
 ## Required file manifest
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ The game logic runs in [Rocq](https://rocq-prover.org/) (formerly Coq),
 interpreted live by [JsCoq](https://github.com/jscoq/jscoq) so you can
 read and step through the proofs on the same page as the running game.
 
+Because the Quake 3 demo license does not permit publishing extracted map
+assets on GitHub Pages, the public site ships the browser shell and Rocq
+theories only.  To actually play q3dm1, extract your own demo assets locally
+with `make assets`, then serve the repo yourself.
+
 See [ARCHITECTURE.md](ARCHITECTURE.md) for the Rocq/JavaScript boundary and
 [V1_CHECKLIST.md](V1_CHECKLIST.md) for the v1 acceptance target.
 
@@ -74,8 +79,8 @@ the shell without assets.
 
 ### Browser regression smoke test
 
-To run the Playwright regression coverage for browser load and q3dm1 render
-startup:
+To run the Playwright regression coverage for browser load plus desktop/mobile
+q3dm1 startup:
 
 ```sh
 npm ci
@@ -83,12 +88,16 @@ npm run playwright:install
 npm run test:q3dm1-browser
 ```
 
-The smoke test runs two scenarios against the local browser build:
+The regression script runs four scenarios against the local browser build:
 
 1. the assetless page load path, to ensure the JsCoq worker bootstrap still
    succeeds without tripping over browser security restrictions
-2. a stubbed `maps/q3dm1.bsp` startup path, to ensure the Rocq-seeded render
-   pipeline reaches its first frame and hides the placeholder
+2. a desktop stubbed `maps/q3dm1.bsp` startup path, to ensure the Rocq-seeded
+   render pipeline reaches its first frame and hides the placeholder
+3. an iPhone-sized portrait startup path, to ensure the mobile controls stay
+   visible, large enough to use, and safely inside the viewport
+4. an iPhone-sized landscape startup path, to ensure the split layout, control
+   reachability, and touch resize handle remain usable after rotation
 
 It writes screenshots plus JSON diagnostics under your system temp directory.
 

--- a/V1_CHECKLIST.md
+++ b/V1_CHECKLIST.md
@@ -63,11 +63,15 @@ investigation proves one is unexpectedly required for the acceptance path:
       on Android) without errors.
 - [ ] JsCoq boots, the Rocq kernel starts, and the IDE panel shows the
       game-core theories loading.
-- [ ] The BSP and texture assets for q3dm1 load from the site build
-      reproducibly — no manual file-copy steps, no ad hoc paths.
+- [ ] The public GitHub Pages shell handles the no-assets path cleanly:
+      q3dm1 content is absent by default, but the page stays usable and tells
+      the user how to provide demo assets locally.
+- [ ] The BSP and texture assets for q3dm1 load reproducibly from a
+      user-supplied Quake 3 Arena Demo package via the documented `make assets`
+      flow — no manual file-copy steps, no ad hoc paths.
 - [ ] A local reproduction works by following the repo docs alone
-      (`make serve` or equivalent) on both desktop and mobile via local
-      network.
+      (`make assets` + `make serve` or equivalent) on both desktop and mobile
+      via local network.
 
 ### Spawn
 
@@ -133,6 +137,9 @@ investigation proves one is unexpectedly required for the acceptance path:
       small to see what is happening.  The drag-to-resize handle works on touch.
 - [ ] The safe-area insets (`env(safe-area-inset-*)`) keep controls off the
       notch and home-bar area on notched iOS devices.
+- [ ] Browser regression coverage exercises q3dm1 startup on desktop plus
+      mobile portrait and landscape layouts, including touch-control visibility
+      and resize-handle behavior.
 
 ### Rocq-powered core
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -137,6 +137,11 @@
     }
 
     #game-overlay {
+      --touch-pad-size: clamp(6.5rem, 24vw, 9rem);
+      --look-pad-width: clamp(7.75rem, 30vw, 11rem);
+      --look-pad-height: var(--touch-pad-size);
+      --jump-button-size: clamp(4.5rem, 16vw, 5.75rem);
+      --touch-controls-gap: clamp(0.75rem, 3vw, 1.15rem);
       position: absolute;
       inset: 0;
       display: flex;
@@ -171,13 +176,13 @@
       width: 100%;
       align-items: flex-end;
       justify-content: space-between;
-      gap: 1rem;
+      gap: var(--touch-controls-gap);
       margin-top: auto;
     }
 
     .touch-cluster {
       display: flex;
-      gap: 0.9rem;
+      gap: var(--touch-controls-gap);
       align-items: flex-end;
     }
 
@@ -188,8 +193,8 @@
 
     .touch-pad {
       position: relative;
-      width: clamp(6.5rem, 24vw, 9rem);
-      height: clamp(6.5rem, 24vw, 9rem);
+      width: var(--touch-pad-size);
+      height: var(--touch-pad-size);
       border-radius: 50%;
       border: 1px solid rgb(160 196 255 / 24%);
       background: rgb(7 10 20 / 52%);
@@ -201,12 +206,23 @@
       -webkit-backdrop-filter: blur(6px);
     }
 
+    [data-touch-control="look-pad"] {
+      width: var(--look-pad-width);
+      height: var(--look-pad-height);
+      border-radius: 1.35rem;
+    }
+
     .touch-pad::before {
       content: '';
       position: absolute;
       inset: 18%;
       border-radius: 50%;
       border: 1px solid rgb(160 196 255 / 14%);
+    }
+
+    [data-touch-control="look-pad"]::before {
+      inset: 14% 10%;
+      border-radius: 1rem;
     }
 
     .touch-pad-label {
@@ -237,9 +253,17 @@
       pointer-events: none;
     }
 
+    .touch-pad.is-active {
+      background: rgb(22 38 71 / 76%);
+      border-color: rgb(160 196 255 / 48%);
+      box-shadow:
+        inset 0 0 0 1px rgb(255 255 255 / 10%),
+        0 0 28px rgb(27 76 162 / 28%);
+    }
+
     #jump-button {
-      min-width: clamp(4.5rem, 16vw, 5.75rem);
-      min-height: clamp(4.5rem, 16vw, 5.75rem);
+      min-width: var(--jump-button-size);
+      min-height: var(--jump-button-size);
       padding: 0.8rem 1rem;
       border: 1px solid rgb(160 196 255 / 28%);
       border-radius: 999px;
@@ -258,6 +282,12 @@
 
     #jump-button:active {
       background: rgb(45 76 126 / 72%);
+    }
+
+    #jump-button.is-active {
+      background: rgb(45 76 126 / 82%);
+      border-color: rgb(160 196 255 / 54%);
+      box-shadow: 0 0 28px rgb(27 76 162 / 32%);
     }
 
     /* ── drag-to-resize handle ───────────────────────────────── */
@@ -318,6 +348,13 @@
        or laptop it is not (height > 560px → desktop query wins).
        ══════════════════════════════════════════════════════════ */
     @media (orientation: landscape) and (max-height: 560px) {
+      #game-overlay {
+        --touch-pad-size: clamp(5rem, 19vh, 6.6rem);
+        --look-pad-width: clamp(7rem, 27vw, 9rem);
+        --look-pad-height: clamp(4.75rem, 17vh, 6rem);
+        --jump-button-size: clamp(4rem, 14vh, 5rem);
+      }
+
       /* ultra-compact header to save vertical pixels */
       #orly-header { padding: 0.2rem 0.75rem; }
       #orly-header h1 { font-size: 0.9rem; }
@@ -347,16 +384,6 @@
         max-width: 18rem;
         font-size: 0.72rem;
       }
-
-      .touch-pad {
-        width: clamp(5.2rem, 20vh, 7rem);
-        height: clamp(5.2rem, 20vh, 7rem);
-      }
-
-      #jump-button {
-        min-width: clamp(4rem, 14vh, 5rem);
-        min-height: clamp(4rem, 14vh, 5rem);
-      }
     }
 
     /* ══════════════════════════════════════════════════════════
@@ -381,10 +408,32 @@
       }
     }
 
+    @media (max-width: 480px) and (pointer: coarse) {
+      #game-overlay {
+        --touch-pad-size: clamp(5.5rem, 28vw, 7.25rem);
+        --look-pad-width: min(46vw, 10.25rem);
+        --look-pad-height: clamp(5.5rem, 24vw, 7rem);
+        --jump-button-size: clamp(4.25rem, 18vw, 5.25rem);
+        --touch-controls-gap: clamp(0.65rem, 3vw, 0.95rem);
+      }
+
+      #game-hint {
+        align-self: flex-start;
+        max-width: min(14rem, calc(100% - 0.5rem));
+        font-size: 0.74rem;
+        line-height: 1.35;
+      }
+    }
+
     @media (pointer: coarse) {
       #game-hint-desktop { display: none; }
       #game-hint-mobile { display: inline; }
       #touch-controls { display: flex; }
+      #resize-handle { flex-basis: 28px; }
+      #resize-handle::before {
+        width: 56px;
+        height: 6px;
+      }
     }
   </style>
 </head>

--- a/docs/index.html
+++ b/docs/index.html
@@ -492,6 +492,10 @@
       statusBar.textContent = '';
     }
 
+    const GAME_TICK_MS = 16;
+    const MAX_FRAME_DT_MS = 100;
+    const MAX_SIMULATION_STEPS = 6;
+
     // ── global error surface ─────────────────────────────────────
     // Catch anything that slips through — script errors, failed fetches,
     // JsCoq internal errors that bubble up as uncaught exceptions.
@@ -737,6 +741,18 @@
         const projMatrix = new Float32Array(16);
         const playerInput = createPlayerInput(canvas, touchOverlay);
         let lastFrameTime = null;
+        let accumulatedDtMs = 0;
+        let latestSnapshot = initialSnapshot;
+        let latestButtons = {
+          forward: false,
+          back: false,
+          left: false,
+          right: false,
+          jump: false,
+        };
+        let pendingYawDelta = 0;
+        let pendingPitchDelta = 0;
+        let pendingJump = false;
 
         function renderSnapshot(snapshot) {
           syncCanvasSize();
@@ -746,18 +762,54 @@
         }
 
         await nextAnimationFrame();
-        renderSnapshot(initialSnapshot);
+        renderSnapshot(latestSnapshot);
 
         // Hide the placeholder only after a real Rocq-seeded frame has drawn.
         hidePlaceholder();
 
         async function frame(now) {
-          const dtMs = lastFrameTime === null
+          const frameDtMs = lastFrameTime === null
             ? 0
-            : Math.min(100, Math.max(0, now - lastFrameTime));
+            : Math.min(MAX_FRAME_DT_MS, Math.max(0, now - lastFrameTime));
           lastFrameTime = now;
-          const snapshot = await rocqBridge.step(playerInput.sample(dtMs));
-          renderSnapshot(snapshot);
+
+          const sampledInput = playerInput.sample(frameDtMs);
+          latestButtons = {
+            forward: sampledInput.forward,
+            back: sampledInput.back,
+            left: sampledInput.left,
+            right: sampledInput.right,
+            jump: sampledInput.jump,
+          };
+          pendingYawDelta += sampledInput.yawDelta;
+          pendingPitchDelta += sampledInput.pitchDelta;
+          pendingJump ||= sampledInput.jump;
+          accumulatedDtMs += frameDtMs;
+
+          let steps = 0;
+          while (accumulatedDtMs >= GAME_TICK_MS && steps < MAX_SIMULATION_STEPS) {
+            latestSnapshot = await rocqBridge.step({
+              ...latestButtons,
+              jump: pendingJump || latestButtons.jump,
+              yawDelta: pendingYawDelta,
+              pitchDelta: pendingPitchDelta,
+              dtMs: GAME_TICK_MS,
+            });
+            pendingYawDelta = 0;
+            pendingPitchDelta = 0;
+            pendingJump = false;
+            accumulatedDtMs -= GAME_TICK_MS;
+            steps++;
+          }
+
+          if (accumulatedDtMs >= GAME_TICK_MS) {
+            console.warn(
+              `orly: dropping ${(accumulatedDtMs / GAME_TICK_MS).toFixed(1)} queued ticks after frame hitch`
+            );
+            accumulatedDtMs %= GAME_TICK_MS;
+          }
+
+          renderSnapshot(latestSnapshot);
           requestAnimationFrame(frame);
         }
         requestAnimationFrame(frame);

--- a/docs/input.js
+++ b/docs/input.js
@@ -178,6 +178,7 @@ function createTouchPad(pad, knob, { accumulateLook = false, onPressChange = nul
   pad.addEventListener('pointermove', onPointerMove);
   pad.addEventListener('pointerup', onPointerEnd);
   pad.addEventListener('pointercancel', onPointerEnd);
+  pad.addEventListener('lostpointercapture', reset);
 
   return {
     sample() {
@@ -198,6 +199,7 @@ function createTouchPad(pad, knob, { accumulateLook = false, onPressChange = nul
       pad.removeEventListener('pointermove', onPointerMove);
       pad.removeEventListener('pointerup', onPointerEnd);
       pad.removeEventListener('pointercancel', onPointerEnd);
+      pad.removeEventListener('lostpointercapture', reset);
     },
   };
 }
@@ -211,8 +213,26 @@ export function createTouchInput(overlay) {
   const jumpButton = overlay.querySelector('[data-touch-control="jump"]');
   let jumpPressed = false;
 
-  const moveControl = createTouchPad(movePad, moveKnob);
-  const lookControl = createTouchPad(lookPad, lookKnob, { accumulateLook: true });
+  function setActiveClass(element, active) {
+    element.classList.toggle('is-active', active);
+  }
+
+  function setJumpPressed(active) {
+    jumpPressed = active;
+    setActiveClass(jumpButton, active);
+  }
+
+  const moveControl = createTouchPad(movePad, moveKnob, {
+    onPressChange(active) {
+      setActiveClass(movePad, active);
+    },
+  });
+  const lookControl = createTouchPad(lookPad, lookKnob, {
+    accumulateLook: true,
+    onPressChange(active) {
+      setActiveClass(lookPad, active);
+    },
+  });
 
   function syncVisibility() {
     overlay.hidden = !coarsePointerQuery.matches;
@@ -220,14 +240,18 @@ export function createTouchInput(overlay) {
 
   function onJumpDown(event) {
     if (event.pointerType === 'mouse') return;
-    jumpPressed = true;
+    setJumpPressed(true);
     jumpButton.setPointerCapture?.(event.pointerId);
     event.preventDefault();
   }
 
   function onJumpEnd(event) {
-    jumpPressed = false;
+    setJumpPressed(false);
     event.preventDefault();
+  }
+
+  function onJumpLostPointerCapture() {
+    setJumpPressed(false);
   }
 
   syncVisibility();
@@ -235,6 +259,7 @@ export function createTouchInput(overlay) {
   jumpButton.addEventListener('pointerdown', onJumpDown);
   jumpButton.addEventListener('pointerup', onJumpEnd);
   jumpButton.addEventListener('pointercancel', onJumpEnd);
+  jumpButton.addEventListener('lostpointercapture', onJumpLostPointerCapture);
   window.addEventListener('blur', onJumpEnd);
 
   return {
@@ -257,11 +282,12 @@ export function createTouchInput(overlay) {
     destroy() {
       moveControl.destroy();
       lookControl.destroy();
-      jumpPressed = false;
+      setJumpPressed(false);
       coarsePointerQuery.removeEventListener('change', syncVisibility);
       jumpButton.removeEventListener('pointerdown', onJumpDown);
       jumpButton.removeEventListener('pointerup', onJumpEnd);
       jumpButton.removeEventListener('pointercancel', onJumpEnd);
+      jumpButton.removeEventListener('lostpointercapture', onJumpLostPointerCapture);
       window.removeEventListener('blur', onJumpEnd);
     },
   };

--- a/scripts/repro-q3dm1-render.mjs
+++ b/scripts/repro-q3dm1-render.mjs
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import { spawn } from 'node:child_process';
-import { chromium } from 'playwright';
+import { chromium, devices } from 'playwright';
 
 const ROOT = process.cwd();
 const DOCS_DIR = path.join(ROOT, 'docs');
@@ -18,6 +18,17 @@ const BOOTSTRAP_FAILURE_RE =
   /launch failure SecurityError|Failed to construct 'Worker'|JsCoq bootstrap failed/i;
 const RENDER_FAILURE_RE = /BSP render init failed|Render error:/i;
 const SUCCESSFUL_RENDER_RE = /render pipeline active/i;
+const MIN_TOUCH_TARGET_PX = 44;
+const MIN_SAFE_AREA_PADDING_PX = 12;
+
+const IPHONE_13 = devices['iPhone 13'];
+const IPHONE_13_LANDSCAPE = {
+  ...IPHONE_13,
+  viewport: {
+    width: IPHONE_13.viewport.height,
+    height: IPHONE_13.viewport.width,
+  },
+};
 
 const STUB_BRIDGE_SOURCE = `
 const VIEW_MATRIX = [1, 0, 0, 0,
@@ -136,9 +147,61 @@ async function gatherSnapshot(page) {
     const placeholderTitle = placeholder?.querySelector('[data-placeholder-role="title"]');
     const placeholderDetail = placeholder?.querySelector('[data-placeholder-role="detail"]');
     const canvas = document.getElementById('game-canvas');
+    const overlay = document.getElementById('game-overlay');
+    const main = document.getElementById('main');
+    const jscoqPanel = document.getElementById('jscoq-panel');
+    const resizeHandle = document.getElementById('resize-handle');
+    const touchControls = document.getElementById('touch-controls');
+    const movePad = document.querySelector('[data-touch-control="move-pad"]');
+    const lookPad = document.querySelector('[data-touch-control="look-pad"]');
+    const jumpButton = document.querySelector('[data-touch-control="jump"]');
+    const desktopHint = document.getElementById('game-hint-desktop');
+    const mobileHint = document.getElementById('game-hint-mobile');
     const assetMap = window.orlyAssets instanceof Map ? window.orlyAssets : null;
 
+    function rectOf(element) {
+      if (!element) return null;
+      const rect = element.getBoundingClientRect();
+      return {
+        left: rect.left,
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom,
+        width: rect.width,
+        height: rect.height,
+      };
+    }
+
+    function visibilityOf(element) {
+      if (!element) return null;
+      const style = window.getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return {
+        hidden: Boolean(element.hidden),
+        display: style.display,
+        visibility: style.visibility,
+        opacity: style.opacity,
+        visible:
+          !element.hidden &&
+          style.display !== 'none' &&
+          style.visibility !== 'hidden' &&
+          Number.parseFloat(style.opacity || '1') > 0 &&
+          rect.width > 0 &&
+          rect.height > 0,
+      };
+    }
+
+    const overlayStyle = overlay ? window.getComputedStyle(overlay) : null;
+    const mainStyle = main ? window.getComputedStyle(main) : null;
+
     return {
+      viewport: {
+        width: window.innerWidth,
+        height: window.innerHeight,
+      },
+      pointer: {
+        coarse: window.matchMedia('(pointer: coarse)').matches,
+      },
       status: statusBar
         ? {
             hidden: statusBar.hidden,
@@ -156,10 +219,44 @@ async function gatherSnapshot(page) {
         : null,
       canvas: canvas
         ? {
-            width: canvas.width,
-            height: canvas.height,
+          width: canvas.width,
+          height: canvas.height,
+          rect: rectOf(canvas),
+        }
+        : null,
+      overlayPadding: overlayStyle
+        ? {
+            top: Number.parseFloat(overlayStyle.paddingTop),
+            right: Number.parseFloat(overlayStyle.paddingRight),
+            bottom: Number.parseFloat(overlayStyle.paddingBottom),
+            left: Number.parseFloat(overlayStyle.paddingLeft),
           }
         : null,
+      main: mainStyle
+        ? {
+            flexDirection: mainStyle.flexDirection,
+          }
+        : null,
+      jscoqPanel: jscoqPanel
+        ? {
+            rect: rectOf(jscoqPanel),
+          }
+        : null,
+      resizeHandle: resizeHandle
+        ? {
+            rect: rectOf(resizeHandle),
+          }
+        : null,
+      hints: {
+        desktop: visibilityOf(desktopHint),
+        mobile: visibilityOf(mobileHint),
+      },
+      touchControls: {
+        ...visibilityOf(touchControls),
+        movePad: rectOf(movePad),
+        lookPad: rectOf(lookPad),
+        jumpButton: rectOf(jumpButton),
+      },
       assetCount: assetMap?.size ?? null,
       jscoqLoaded: Boolean(document.querySelector('.CodeMirror')),
     };
@@ -298,11 +395,140 @@ function assertRenderStartupScenario(snapshot, consoleEvents) {
   }
 }
 
-async function runScenario(browser, scenarioName, outDir, port) {
-  const scenarioRoot = await createScenarioRoot(scenarioName);
+function assertDesktopRenderStartupScenario(snapshot, consoleEvents) {
+  assertRenderStartupScenario(snapshot, consoleEvents);
+  if (snapshot.pointer?.coarse) {
+    throw new Error('desktop render scenario unexpectedly reported a coarse pointer');
+  }
+  if (snapshot.touchControls?.visible) {
+    throw new Error('desktop render scenario unexpectedly showed touch controls');
+  }
+  if (!snapshot.hints?.desktop?.visible) {
+    throw new Error('desktop hint should stay visible in desktop render scenario');
+  }
+}
+
+function assertRectWithinViewport(name, rect, viewport) {
+  if (!rect) {
+    throw new Error(`${name} rect missing`);
+  }
+  if (rect.left < -1 || rect.top < -1 ||
+      rect.right > viewport.width + 1 || rect.bottom > viewport.height + 1) {
+    throw new Error(`${name} fell outside the viewport`);
+  }
+}
+
+function assertTouchTarget(name, rect) {
+  if (!rect) {
+    throw new Error(`${name} rect missing`);
+  }
+  if (rect.width < MIN_TOUCH_TARGET_PX || rect.height < MIN_TOUCH_TARGET_PX) {
+    throw new Error(`${name} target smaller than ${MIN_TOUCH_TARGET_PX}px`);
+  }
+}
+
+function assertMobileRenderStartupScenario(snapshot, consoleEvents, orientation) {
+  assertRenderStartupScenario(snapshot, consoleEvents);
+  if (!snapshot.pointer?.coarse) {
+    throw new Error('mobile render scenario did not report a coarse pointer');
+  }
+  if (!snapshot.touchControls?.visible) {
+    throw new Error('mobile render scenario did not show touch controls');
+  }
+  if (!snapshot.hints?.mobile?.visible || snapshot.hints?.desktop?.visible) {
+    throw new Error('mobile hints did not switch correctly for coarse pointers');
+  }
+
+  assertTouchTarget('move pad', snapshot.touchControls.movePad);
+  assertTouchTarget('look pad', snapshot.touchControls.lookPad);
+  assertTouchTarget('jump button', snapshot.touchControls.jumpButton);
+
+  if (snapshot.touchControls.lookPad.width < snapshot.touchControls.movePad.width) {
+    throw new Error('look pad should be at least as wide as the move pad on mobile');
+  }
+
+  assertRectWithinViewport('move pad', snapshot.touchControls.movePad, snapshot.viewport);
+  assertRectWithinViewport('look pad', snapshot.touchControls.lookPad, snapshot.viewport);
+  assertRectWithinViewport('jump button', snapshot.touchControls.jumpButton, snapshot.viewport);
+  assertRectWithinViewport('resize handle', snapshot.resizeHandle?.rect, snapshot.viewport);
+
+  if (!snapshot.overlayPadding ||
+      snapshot.overlayPadding.top < MIN_SAFE_AREA_PADDING_PX ||
+      snapshot.overlayPadding.right < MIN_SAFE_AREA_PADDING_PX ||
+      snapshot.overlayPadding.bottom < MIN_SAFE_AREA_PADDING_PX ||
+      snapshot.overlayPadding.left < MIN_SAFE_AREA_PADDING_PX) {
+    throw new Error('mobile overlay padding did not preserve safe-area spacing');
+  }
+
+  if (!snapshot.canvas?.rect || !snapshot.jscoqPanel?.rect) {
+    throw new Error('mobile render scenario missing canvas or JsCoq panel bounds');
+  }
+
+  if (orientation === 'portrait') {
+    if (snapshot.main?.flexDirection !== 'column') {
+      throw new Error(`expected portrait layout to stack panels, got ${snapshot.main?.flexDirection}`);
+    }
+    if (snapshot.canvas.rect.height < 200) {
+      throw new Error('portrait canvas became too short for playability');
+    }
+  } else if (orientation === 'landscape') {
+    if (snapshot.main?.flexDirection !== 'row') {
+      throw new Error(`expected landscape layout to split horizontally, got ${snapshot.main?.flexDirection}`);
+    }
+    if (snapshot.canvas.rect.width < 240) {
+      throw new Error('landscape canvas became too narrow for playability');
+    }
+  }
+}
+
+async function dragResizeHandle(page, { deltaX = 0, deltaY = 0 }) {
+  const handle = page.locator('#resize-handle');
+  const box = await handle.boundingBox();
+  if (!box) {
+    throw new Error('resize handle is not visible');
+  }
+
+  const startX = box.x + box.width / 2;
+  const startY = box.y + box.height / 2;
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX + deltaX, startY + deltaY, { steps: 8 });
+  await page.mouse.up();
+  await page.waitForTimeout(150);
+}
+
+async function exerciseResizeHandle(page, orientation) {
+  const before = await gatherSnapshotWithRetry(page);
+  if (orientation === 'portrait') {
+    await dragResizeHandle(page, { deltaY: -80 });
+  } else {
+    await dragResizeHandle(page, { deltaX: -100 });
+  }
+  const after = await gatherSnapshotWithRetry(page);
+
+  const beforePanel = before.jscoqPanel?.rect;
+  const afterPanel = after.jscoqPanel?.rect;
+  if (!beforePanel || !afterPanel) {
+    throw new Error('resize handle diagnostics missing JsCoq panel bounds');
+  }
+
+  if (orientation === 'portrait') {
+    if (afterPanel.height <= beforePanel.height + 20) {
+      throw new Error('portrait resize handle did not grow the JsCoq panel');
+    }
+  } else if (afterPanel.width <= beforePanel.width + 20) {
+    throw new Error('landscape resize handle did not grow the JsCoq panel');
+  }
+
+  return { before, after };
+}
+
+async function runScenario(browser, scenario, outDir, port) {
+  const scenarioRoot = await createScenarioRoot(scenario.rootScenario ?? scenario.name);
   const { server, readLogs } = startStaticServer(scenarioRoot, port);
   const url = `http://127.0.0.1:${port}/`;
   const consoleEvents = [];
+  let context = null;
   let page = null;
 
   try {
@@ -313,7 +539,8 @@ async function runScenario(browser, scenarioName, outDir, port) {
       );
     });
 
-    page = await browser.newPage({ viewport: { width: 1280, height: 720 } });
+    context = await browser.newContext(scenario.contextOptions ?? { viewport: { width: 1280, height: 720 } });
+    page = await context.newPage();
     attachEventCapture(page, consoleEvents);
 
     await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 120000 });
@@ -322,37 +549,43 @@ async function runScenario(browser, scenarioName, outDir, port) {
     const snapshot = await waitForScenario(
       page,
       consoleEvents,
-      scenarioName === 'browser-load-no-assets'
+      scenario.name === 'browser-load-no-assets'
         ? current => current.jscoqLoaded && current.status?.hidden === true
         : current => current.placeholder?.hidden === true
     );
 
-    const screenshotPath = path.join(outDir, `${scenarioName}.png`);
+    const extraInteractions = scenario.afterReady
+      ? await scenario.afterReady(page)
+      : null;
+    const interactions = {
+      readySnapshot: snapshot,
+      ...(extraInteractions ?? {}),
+    };
+    const finalSnapshot = await gatherSnapshotWithRetry(page);
+
+    const screenshotPath = path.join(outDir, `${scenario.name}.png`);
     await page.screenshot({ path: screenshotPath, fullPage: true });
 
-    if (scenarioName === 'browser-load-no-assets') {
-      assertNoAssetsScenario(snapshot, consoleEvents);
-    } else {
-      assertRenderStartupScenario(snapshot, consoleEvents);
-    }
+    scenario.assert(finalSnapshot, consoleEvents, interactions);
 
     return {
-      scenario: scenarioName,
+      scenario: scenario.name,
       passed: true,
       url,
-      snapshot,
+      snapshot: finalSnapshot,
+      interactions,
       consoleEvents,
       serverLogs: readLogs(),
       screenshotPath,
     };
   } catch (error) {
-    const screenshotPath = path.join(outDir, `${scenarioName}.png`);
+    const screenshotPath = path.join(outDir, `${scenario.name}.png`);
     await page?.screenshot({ path: screenshotPath, fullPage: true }).catch(() => {});
     const failureSnapshot = page
       ? await gatherSnapshotWithRetry(page).catch(() => null)
       : null;
     return {
-      scenario: scenarioName,
+      scenario: scenario.name,
       passed: false,
       url,
       failure: error.message,
@@ -362,7 +595,7 @@ async function runScenario(browser, scenarioName, outDir, port) {
       screenshotPath,
     };
   } finally {
-    await page?.close().catch(() => {});
+    await context?.close().catch(() => {});
     server.kill('SIGTERM');
     await new Promise(resolve => {
       if (server.exitCode !== null) {
@@ -383,8 +616,53 @@ async function main() {
     const diagnosticsPath = path.join(outDir, 'diagnostics.json');
     const scenarios = [];
 
-    for (const [index, scenarioName] of ['browser-load-no-assets', 'q3dm1-render-startup'].entries()) {
-      scenarios.push(await runScenario(browser, scenarioName, outDir, PORT_BASE + index));
+    const scenarioConfigs = [
+      {
+        name: 'browser-load-no-assets',
+        assert(snapshot, consoleEvents) {
+          assertNoAssetsScenario(snapshot, consoleEvents);
+        },
+      },
+      {
+        name: 'q3dm1-render-startup-desktop',
+        rootScenario: 'q3dm1-render-startup',
+        contextOptions: {
+          viewport: { width: 1280, height: 720 },
+        },
+        assert(snapshot, consoleEvents) {
+          assertDesktopRenderStartupScenario(snapshot, consoleEvents);
+        },
+      },
+      {
+        name: 'q3dm1-render-startup-mobile-portrait',
+        rootScenario: 'q3dm1-render-startup',
+        contextOptions: IPHONE_13,
+        async afterReady(page) {
+          return {
+            resize: await exerciseResizeHandle(page, 'portrait'),
+          };
+        },
+        assert(snapshot, consoleEvents, interactions) {
+          assertMobileRenderStartupScenario(interactions.readySnapshot, consoleEvents, 'portrait');
+        },
+      },
+      {
+        name: 'q3dm1-render-startup-mobile-landscape',
+        rootScenario: 'q3dm1-render-startup',
+        contextOptions: IPHONE_13_LANDSCAPE,
+        async afterReady(page) {
+          return {
+            resize: await exerciseResizeHandle(page, 'landscape'),
+          };
+        },
+        assert(snapshot, consoleEvents, interactions) {
+          assertMobileRenderStartupScenario(interactions.readySnapshot, consoleEvents, 'landscape');
+        },
+      },
+    ];
+
+    for (const [index, scenario] of scenarioConfigs.entries()) {
+      scenarios.push(await runScenario(browser, scenario, outDir, PORT_BASE + index));
     }
 
     const diagnostics = {


### PR DESCRIPTION
This plan is down to the final guardrails for q3dm1 playability: adding regression coverage for desktop and mobile behavior so the demo stays stable as the core evolves. It also updates the setup docs and acceptance notes to match the shipped path and make the playable demo easier to reproduce.

Fixes #16.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] Add desktop and mobile q3dm1 playability regression coverage <!-- type:spec -->
- [x] Document playable demo setup and acceptance updates <!-- type:spec -->
- [x] Polish mobile controls and phone-sized q3dm1 layout <!-- type:spec -->
- [x] Harden q3dm1 gameplay loop for stable Rocq-owned play <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->