### PR TITLE
Deployed demo throws 'Cannot read properties of undefined (reading 'length')' in the browser (closes #60)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -59,6 +59,28 @@ jobs:
         with:
           path: docs
 
+  smoke-pr:
+    if: github.event_name == 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install browser tooling
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npm run --silent playwright:install
+
+      - name: Smoke local browser demo
+        run: npm run --silent test:q3dm1-browser
+
   deploy:
     if: github.event_name != 'pull_request'
     needs: build

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,9 @@ THEORIES := \
 # file served to the JsCoq IDE panel in the browser.  It is the
 # concatenation of the three game-core theories in dependency order
 # (BspBinary → BspEntity → GameState) with cross-file
-# "From Bsp Require Import" lines stripped (their content is inlined).
+# "From Bsp Require Import" lines stripped (their content is inlined),
+# and "From Stdlib Require Import" rewritten to plain "Require Import"
+# so the bundled theory still loads under JsCoq's older stdlib layout.
 # JsCoq 0.17.1 runs Rocq 8.17.1 and cannot load pre-compiled .vo
 # packages built with our system Rocq 9.x; this flat-file approach
 # lets JsCoq compile the theories on the fly using only the stdlib.
@@ -45,7 +47,7 @@ PAGES_MANIFEST    = $(ASSETS_DIR)/manifest.json
 $(BSP_CORE_V): $(BSP_CORE_SRCS)
 	mkdir -p $(DOCS_THEORIES_DIR)
 	{ cat $(BSP_CORE_SRCS); } \
-	  | grep -v '^From Bsp Require Import' > $@
+	  | sed -E '/^From Bsp Require Import /d; s/^From Stdlib Require Import ([^.]+)\.$$/Require Import \1./' > $@
 
 browser-theories: $(BSP_CORE_V)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -516,12 +516,28 @@
     const placeholderDetail =
       gamePlaceholder.querySelector('[data-placeholder-role="detail"]');
 
+    function textOrEmpty(value) {
+      return value == null ? '' : String(value);
+    }
+
+    function errorDetail(value, fallback = 'Unknown error') {
+      if (typeof value?.message === 'string' && value.message.length > 0) {
+        return value.message;
+      }
+      if (typeof value === 'string' && value.length > 0) {
+        return value;
+      }
+      return fallback;
+    }
+
     function showPlaceholder(title, detail = '', state = 'loading') {
+      const safeTitle = textOrEmpty(title);
+      const safeDetail = textOrEmpty(detail);
       gamePlaceholder.hidden = false;
       gamePlaceholder.dataset.state = state;
-      placeholderTitle.textContent = title;
-      placeholderDetail.textContent = detail;
-      placeholderDetail.hidden = detail.length === 0;
+      placeholderTitle.textContent = safeTitle;
+      placeholderDetail.textContent = safeDetail;
+      placeholderDetail.hidden = safeDetail.length === 0;
     }
 
     function hidePlaceholder() {
@@ -549,11 +565,12 @@
     // Catch anything that slips through — script errors, failed fetches,
     // JsCoq internal errors that bubble up as uncaught exceptions.
     window.addEventListener('error', (e) => {
-      showStatus(`Error: ${e.message}`, 'error');
-      showPlaceholder('Browser startup failed', e.message, 'error');
+      const msg = errorDetail(e);
+      showStatus(`Error: ${msg}`, 'error');
+      showPlaceholder('Browser startup failed', msg, 'error');
     });
     window.addEventListener('unhandledrejection', (e) => {
-      const msg = e.reason?.message || e.reason || 'Unknown error';
+      const msg = errorDetail(e.reason);
       showStatus(`Error: ${msg}`, 'error');
       showPlaceholder('Browser startup failed', msg, 'error');
     });
@@ -694,8 +711,9 @@
       rocqBridge = createRocqBridge(coq);
       jscoqOk = true;
     } catch (err) {
-      showStatus(`Failed to load JsCoq: ${err.message}`, 'error');
-      showPlaceholder('JsCoq startup failed', err.message, 'error');
+      const msg = errorDetail(err);
+      showStatus(`Failed to load JsCoq: ${msg}`, 'error');
+      showPlaceholder('JsCoq startup failed', msg, 'error');
       console.error('JsCoq bootstrap failed:', err);
     }
 
@@ -722,8 +740,9 @@
     } catch (err) {
       console.error('Asset loading failed:', err);
       window.orlyAssets = new Map();
-      showPlaceholder('Asset loading failed', err.message, 'error');
-      if (jscoqOk) showStatus(`Failed to load assets: ${err.message}`, 'error');
+      const msg = errorDetail(err);
+      showPlaceholder('Asset loading failed', msg, 'error');
+      if (jscoqOk) showStatus(`Failed to load assets: ${msg}`, 'error');
     }
 
     // ── game canvas sizing ───────────────────────────────────────
@@ -889,8 +908,9 @@
         console.log('orly: render pipeline active — snapshot seeded from Rocq state');
       } catch (err) {
         console.error('BSP render init failed:', err);
-        showStatus(`Render error: ${err.message}`, 'error');
-        showPlaceholder('Render startup failed', err.message, 'error');
+        const msg = errorDetail(err);
+        showStatus(`Render error: ${msg}`, 'error');
+        showPlaceholder('Render startup failed', msg, 'error');
       }
     }
     // ── direction-aware drag-to-resize ───────────────────────────

--- a/docs/theories/BspCore.v
+++ b/docs/theories/BspCore.v
@@ -7,9 +7,9 @@
     These primitives are the only code that touches raw bytes; all lump
     parsers call these and never index into [bytes] directly. *)
 
-From Stdlib Require Import List.
-From Stdlib Require Import ZArith.
-From Stdlib Require Import QArith.
+Require Import List.
+Require Import ZArith.
+Require Import QArith.
 Import ListNotations.
 Open Scope Z_scope.
 
@@ -192,9 +192,9 @@ Proof. vm_compute. reflexivity. Qed.
 
     All characters are [Z] values representing ASCII code points. *)
 
-From Stdlib Require Import List.
-From Stdlib Require Import ZArith.
-From Stdlib Require Import Bool.
+Require Import List.
+Require Import ZArith.
+Require Import Bool.
 Import ListNotations.
 Open Scope Z_scope.
 
@@ -606,10 +606,10 @@ Proof. vm_compute. reflexivity. Qed.
     All spatial quantities use [Q] rationals, matching the BSP parser
     conventions in [BspPlaneVertex].  Angles are in degrees (Q). *)
 
-From Stdlib Require Import List.
-From Stdlib Require Import ZArith.
-From Stdlib Require Import QArith.
-From Stdlib Require Import Lia.
+Require Import List.
+Require Import ZArith.
+Require Import QArith.
+Require Import Lia.
 Import ListNotations.
 Open Scope Z_scope.
 

--- a/scripts/repro-q3dm1-render.mjs
+++ b/scripts/repro-q3dm1-render.mjs
@@ -23,6 +23,8 @@ const TIMEOUT_MS = Number.parseInt(process.env.ORLY_REPRO_TIMEOUT_MS ?? '20000',
 const POLL_MS = 500;
 const BOOTSTRAP_FAILURE_RE =
   /launch failure SecurityError|Failed to construct 'Worker'|JsCoq bootstrap failed/i;
+const ROCQ_STARTUP_FAILURE_RE =
+  /Coq Exception|Cannot find a physical path bound to logical path|Rocq bridge helper definitions were not found/i;
 const RENDER_FAILURE_RE = /BSP render init failed|Render error:/i;
 const SUCCESSFUL_RENDER_RE = /render pipeline active/i;
 const MIN_TOUCH_TARGET_PX = 44;
@@ -328,7 +330,52 @@ function hasEvent(consoleEvents, pattern) {
   return consoleEvents.some(event => pattern.test(event.text));
 }
 
+function findEvent(consoleEvents, predicate) {
+  return consoleEvents.find(predicate) ?? null;
+}
+
+function formatEventLocation(event) {
+  const url = event.location?.url;
+  const lineNumber = event.location?.lineNumber;
+  const columnNumber = event.location?.columnNumber;
+  if (!url) return '';
+  const line = Number.isInteger(lineNumber) ? lineNumber + 1 : null;
+  const column = Number.isInteger(columnNumber) ? columnNumber + 1 : null;
+  if (line !== null && column !== null) {
+    return ` @ ${url}:${line}:${column}`;
+  }
+  if (line !== null) {
+    return ` @ ${url}:${line}`;
+  }
+  return ` @ ${url}`;
+}
+
+function summarizeEvent(event) {
+  if (!event) return '';
+  const text = String(event.text ?? '').trim();
+  if (event.kind === 'pageerror') {
+    const stack = String(event.stack ?? '').trim();
+    if (stack) {
+      return `${text}\n${stack}`;
+    }
+  }
+  return `${text}${formatEventLocation(event)}`;
+}
+
+function detectRocqStartupFailure(consoleEvents) {
+  return findEvent(
+    consoleEvents,
+    event =>
+      ROCQ_STARTUP_FAILURE_RE.test(event.text) ||
+      (event.kind === 'console' && event.type === 'error' && /CoqExn/i.test(event.text))
+  );
+}
+
 function detectFailure(snapshot, consoleEvents) {
+  const rocqStartupFailure = detectRocqStartupFailure(consoleEvents);
+  if (rocqStartupFailure) {
+    return `rocq-startup-failed: ${summarizeEvent(rocqStartupFailure)}`;
+  }
   if (hasEvent(consoleEvents, BOOTSTRAP_FAILURE_RE)) {
     return 'jscoq-bootstrap-failed';
   }
@@ -358,16 +405,25 @@ async function waitForScenario(page, consoleEvents, predicate) {
 
 function attachEventCapture(page, consoleEvents) {
   page.on('console', msg => {
+    const location = msg.location();
     consoleEvents.push({
       kind: 'console',
       type: msg.type(),
       text: msg.text(),
+      location: location?.url
+        ? {
+            url: location.url,
+            lineNumber: location.lineNumber,
+            columnNumber: location.columnNumber,
+          }
+        : null,
     });
   });
   page.on('pageerror', error => {
     consoleEvents.push({
       kind: 'pageerror',
       text: error.message,
+      stack: error.stack ?? '',
     });
   });
   page.on('requestfailed', request => {


### PR DESCRIPTION
Fixes #60.

This PR now fixes the JsCoq/Rocq browser startup incompatibility in the bundled theory imports that was triggering the deployed demo crash. It also hardens the browser error UI when startup details are missing and adds PR-time browser smoke checks so this kind of regression gets caught before merge.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] Guard browser error UI against undefined details <!-- type:spec -->
- [x] Run browser smoke checks in PR workflows <!-- type:spec -->
- [x] Fix JsCoq Stdlib imports in browser theory bundle <!-- type:spec -->
- [x] Capture Rocq startup failures in browser smoke tests <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->