### PR TITLE
Add a 'copy stack trace' button to the demo's in-browser error overlay (closes #61)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,6 +38,19 @@ jobs:
           rm -rf docs/assets
           make stage-pages-map
 
+      - name: Stamp demo build metadata
+        run: |
+          demo_version="$(node -p "require('./package.json').version")"
+          built_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          cat > docs/build-info.json <<EOF
+          {
+            "version": "${demo_version}",
+            "gitSha": "${GITHUB_SHA}",
+            "builtAt": "${built_at}",
+            "source": "github-actions"
+          }
+          EOF
+
       - name: Verify licensed Pages map artifact
         run: |
           expected_sha256='dc86e859e7f4eeadc734308bbd68326b32e9ab2532c316b252ec944ff03a5ce4'
@@ -47,7 +60,10 @@ jobs:
 
           test -f docs/assets/manifest.json
           test -f docs/assets/maps/am_lavaarena.bsp
+          test -f docs/build-info.json
           grep -Fx '  "maps/am_lavaarena.bsp"' docs/assets/manifest.json
+          grep -F "\"gitSha\": \"${GITHUB_SHA}\"" docs/build-info.json
+          grep -F '"source": "github-actions"' docs/build-info.json
           test "$actual_sha256" = "$expected_sha256"
           test "$actual_size" = "$expected_size"
           cmp --silent docs/vendor/maps/openarena/am_lavaarena.bsp docs/assets/maps/am_lavaarena.bsp

--- a/docs/build-info.json
+++ b/docs/build-info.json
@@ -1,0 +1,6 @@
+{
+  "version": "1.0.0",
+  "gitSha": "unknown",
+  "builtAt": "unknown",
+  "source": "checked-in-default"
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -117,6 +117,14 @@
       background:
         radial-gradient(circle at center, rgb(13 17 30 / 74%), rgb(0 0 0 / 92%));
     }
+    #game-placeholder .title-row {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      max-width: min(32rem, calc(100% - 2rem));
+    }
     #game-placeholder .label {
       font-size: 1.5rem;
       color: #f3f7ff;
@@ -125,6 +133,42 @@
       max-width: min(28rem, calc(100% - 2rem));
       color: #b7c4db;
       line-height: 1.45;
+    }
+    #copy-error-report {
+      padding: 0.45rem 0.85rem;
+      border: 1px solid rgb(255 180 180 / 36%);
+      border-radius: 999px;
+      background: rgb(39 11 11 / 72%);
+      color: #ffe0e0;
+      font: inherit;
+      font-size: 0.82rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      pointer-events: auto;
+      cursor: pointer;
+    }
+    #copy-error-report:hover {
+      background: rgb(65 18 18 / 80%);
+      border-color: rgb(255 180 180 / 54%);
+    }
+    #copy-error-report:focus-visible {
+      outline: 2px solid #ffd3d3;
+      outline-offset: 2px;
+    }
+    #error-copy-fallback {
+      width: min(34rem, calc(100% - 2rem));
+      min-height: 11rem;
+      padding: 0.85rem;
+      border: 1px solid rgb(255 180 180 / 28%);
+      border-radius: 0.75rem;
+      background: rgb(18 6 6 / 92%);
+      color: #ffe7e7;
+      font: 0.78rem/1.45 ui-monospace, SFMono-Regular, SFMono-Regular, Consolas, monospace;
+      resize: vertical;
+      pointer-events: auto;
+    }
+    #error-copy-fallback::selection {
+      background: rgb(160 196 255 / 36%);
     }
     #game-placeholder[data-state="error"] .label {
       color: #ffb4b4;
@@ -474,10 +518,25 @@
           </div>
         </div>
         <div id="game-placeholder" data-state="loading" aria-live="polite">
-          <span class="label" data-placeholder-role="title">Loading browser shell…</span>
+          <div class="title-row">
+            <span class="label" data-placeholder-role="title">Loading browser shell…</span>
+            <button
+              id="copy-error-report"
+              type="button"
+              data-placeholder-role="copy-button"
+              hidden
+            >Copy</button>
+          </div>
           <span class="detail" data-placeholder-role="detail">
             Booting JsCoq and checking whether a playable BSP is available.
           </span>
+          <textarea
+            id="error-copy-fallback"
+            data-placeholder-role="copy-fallback"
+            aria-label="Selectable error report text"
+            readonly
+            hidden
+          ></textarea>
         </div>
     </div>
 
@@ -515,6 +574,14 @@
       gamePlaceholder.querySelector('[data-placeholder-role="title"]');
     const placeholderDetail =
       gamePlaceholder.querySelector('[data-placeholder-role="detail"]');
+    const copyErrorButton =
+      gamePlaceholder.querySelector('[data-placeholder-role="copy-button"]');
+    const copyFallback =
+      gamePlaceholder.querySelector('[data-placeholder-role="copy-fallback"]');
+
+    const COPY_BUTTON_LABEL = 'Copy';
+    const COPY_BUTTON_COPIED_LABEL = 'Copied!';
+    let copyFeedbackTimeoutId = null;
 
     function textOrEmpty(value) {
       return value == null ? '' : String(value);
@@ -638,8 +705,116 @@
       }
     }
 
+    function clearCopyFeedbackTimer() {
+      if (copyFeedbackTimeoutId !== null) {
+        window.clearTimeout(copyFeedbackTimeoutId);
+        copyFeedbackTimeoutId = null;
+      }
+    }
+
+    function resetErrorCopyUi() {
+      clearCopyFeedbackTimer();
+      copyErrorButton.textContent = COPY_BUTTON_LABEL;
+      copyFallback.hidden = true;
+      copyFallback.value = '';
+    }
+
+    function syncErrorCopyUi() {
+      const hasErrorReport =
+        gamePlaceholder.dataset.state === 'error' && window.orlyErrorReport !== null;
+      copyErrorButton.hidden = !hasErrorReport;
+      if (!hasErrorReport) resetErrorCopyUi();
+    }
+
+    function formatErrorLocation(location) {
+      if (!location) return 'unknown';
+      const parts = [];
+      const url = firstNonEmptyText(location.url);
+      if (url.length > 0) parts.push(url);
+      if (Number.isInteger(location.line)) parts.push(`line ${location.line}`);
+      if (Number.isInteger(location.column)) parts.push(`column ${location.column}`);
+      return parts.length > 0 ? parts.join(', ') : 'unknown';
+    }
+
+    function formatBuildMetadata(build) {
+      const buildInfo = normalizeBuildInfo(build) ?? DEFAULT_BUILD_INFO;
+      const lines = [
+        `Build version: ${buildInfo.version}`,
+        `Build git SHA: ${buildInfo.gitSha}`,
+        `Build timestamp: ${buildInfo.builtAt}`,
+        `Build source: ${buildInfo.source}`,
+      ];
+      const loadError = firstNonEmptyText(build?.loadError);
+      if (loadError.length > 0) {
+        lines.push(`Build metadata load error: ${loadError}`);
+      }
+      return lines;
+    }
+
+    function formatErrorReportForClipboard(report = window.orlyErrorReport) {
+      if (!report) return '';
+      const raw = firstNonEmptyText(report.raw);
+      const stack = firstNonEmptyText(report.stack);
+      const lines = [
+        '```text',
+        `Title: ${firstNonEmptyText(report.title, 'Unknown title')}`,
+        `Status: ${firstNonEmptyText(report.status, 'Unknown status')}`,
+        `Message: ${firstNonEmptyText(report.message, 'Unknown error')}`,
+        `Source: ${firstNonEmptyText(report.source, 'unknown')}`,
+        `Captured at: ${firstNonEmptyText(report.capturedAt, 'unknown')}`,
+        `Page URL: ${window.location.href}`,
+        `User agent: ${navigator.userAgent}`,
+        ...formatBuildMetadata(report.build),
+        `Location: ${formatErrorLocation(report.location)}`,
+        '',
+        'Stack trace:',
+        stack.length > 0 ? stack : '(missing)',
+      ];
+      if (raw.length > 0 && raw !== stack) {
+        lines.push('', 'Raw error:', raw);
+      }
+      lines.push('```');
+      return lines.join('\n');
+    }
+
+    function showCopyFallback(text) {
+      copyFallback.value = text;
+      copyFallback.hidden = false;
+      copyFallback.focus();
+      copyFallback.select();
+      copyFallback.setSelectionRange(0, text.length);
+    }
+
+    function showCopiedFeedback() {
+      clearCopyFeedbackTimer();
+      copyErrorButton.textContent = COPY_BUTTON_COPIED_LABEL;
+      copyFeedbackTimeoutId = window.setTimeout(() => {
+        copyErrorButton.textContent = COPY_BUTTON_LABEL;
+        copyFeedbackTimeoutId = null;
+      }, 1000);
+    }
+
+    async function copyCurrentErrorReport() {
+      const text = formatErrorReportForClipboard();
+      if (text.length === 0) return;
+      if (typeof navigator.clipboard?.writeText === 'function') {
+        try {
+          await navigator.clipboard.writeText(text);
+          copyFallback.hidden = true;
+          copyFallback.value = '';
+          showCopiedFeedback();
+          return;
+        } catch (err) {
+          console.warn('Clipboard write failed, falling back to selectable text:', err);
+        }
+      }
+      copyErrorButton.textContent = COPY_BUTTON_LABEL;
+      showCopyFallback(text);
+    }
+
     function clearErrorReport() {
       window.orlyErrorReport = null;
+      syncErrorCopyUi();
     }
 
     function captureErrorReport({
@@ -662,6 +837,8 @@
         showStatus(report.status, 'error');
       }
       showPlaceholder(report.title, report.message, 'error');
+      resetErrorCopyUi();
+      syncErrorCopyUi();
       return report;
     }
 
@@ -674,6 +851,7 @@
       placeholderDetail.textContent = safeDetail;
       placeholderDetail.hidden = safeDetail.length === 0;
       if (state !== 'error') clearErrorReport();
+      else syncErrorCopyUi();
     }
 
     function hidePlaceholder() {
@@ -696,6 +874,9 @@
 
     window.orlyBuildInfo = await loadBuildInfo();
     clearErrorReport();
+    copyErrorButton.addEventListener('click', () => {
+      void copyCurrentErrorReport();
+    });
 
     const GAME_TICK_MS = 16;
     const MAX_FRAME_DT_MS = 100;

--- a/docs/index.html
+++ b/docs/index.html
@@ -596,6 +596,48 @@
       return normalizeErrorReport(value, fallback).message;
     }
 
+    const DEFAULT_BUILD_INFO = Object.freeze({
+      version: '1.0.0',
+      gitSha: 'unknown',
+      builtAt: 'unknown',
+      source: 'checked-in-default',
+    });
+
+    function normalizeBuildInfo(value) {
+      if (typeof value !== 'object' || value === null) return null;
+      const buildInfo = {
+        version: firstNonEmptyText(value.version, DEFAULT_BUILD_INFO.version),
+        gitSha: firstNonEmptyText(value.gitSha, DEFAULT_BUILD_INFO.gitSha),
+        builtAt: firstNonEmptyText(value.builtAt, DEFAULT_BUILD_INFO.builtAt),
+        source: firstNonEmptyText(value.source, DEFAULT_BUILD_INFO.source),
+      };
+      const loadError = firstNonEmptyText(value.loadError);
+      if (loadError.length > 0) buildInfo.loadError = loadError;
+      return buildInfo;
+    }
+
+    function currentBuildInfo() {
+      const buildInfo = normalizeBuildInfo(window.orlyBuildInfo);
+      return buildInfo ? { ...buildInfo } : { ...DEFAULT_BUILD_INFO };
+    }
+
+    async function loadBuildInfo() {
+      const buildInfoUrl = new URL('./build-info.json', window.location.href);
+      try {
+        const resp = await fetch(buildInfoUrl);
+        if (!resp.ok) throw new Error(`build metadata fetch failed: HTTP ${resp.status}`);
+        const buildInfo = normalizeBuildInfo(await resp.json());
+        if (!buildInfo) throw new Error('build metadata payload is not an object');
+        return buildInfo;
+      } catch (err) {
+        return {
+          ...DEFAULT_BUILD_INFO,
+          source: 'fallback',
+          loadError: errorDetail(err),
+        };
+      }
+    }
+
     function clearErrorReport() {
       window.orlyErrorReport = null;
     }
@@ -612,6 +654,7 @@
         title: textOrEmpty(title),
         status: textOrEmpty(status),
         capturedAt: new Date().toISOString(),
+        build: currentBuildInfo(),
         ...normalizeErrorReport(error, fallback),
       };
       window.orlyErrorReport = report;
@@ -651,6 +694,7 @@
       statusBar.textContent = '';
     }
 
+    window.orlyBuildInfo = await loadBuildInfo();
     clearErrorReport();
 
     const GAME_TICK_MS = 16;

--- a/docs/index.html
+++ b/docs/index.html
@@ -520,14 +520,106 @@
       return value == null ? '' : String(value);
     }
 
+    function firstNonEmptyText(...values) {
+      for (const value of values) {
+        const text = textOrEmpty(value).trim();
+        if (text.length > 0) return text;
+      }
+      return '';
+    }
+
+    function stringifyErrorValue(value) {
+      if (value == null) return '';
+      if (typeof value === 'string') return value;
+      if (value instanceof Error) {
+        return firstNonEmptyText(value.stack, value.message, value.name);
+      }
+      try {
+        const seen = new WeakSet();
+        const json = JSON.stringify(
+          value,
+          (_key, current) => {
+            if (typeof current === 'bigint') return current.toString();
+            if (current instanceof Error) {
+              return {
+                name: current.name,
+                message: current.message,
+                stack: current.stack ?? '',
+              };
+            }
+            if (typeof current !== 'object' || current === null) return current;
+            if (seen.has(current)) return '[Circular]';
+            seen.add(current);
+            return current;
+          },
+          2
+        );
+        if (typeof json === 'string' && json.length > 0) return json;
+      } catch {}
+      return textOrEmpty(value);
+    }
+
+    function errorLocation(value) {
+      const url = firstNonEmptyText(value?.filename, value?.sourceURL);
+      const line = Number.isInteger(value?.lineno) ? value.lineno : null;
+      const column = Number.isInteger(value?.colno) ? value.colno : null;
+      if (!url && line === null && column === null) return null;
+      return { url, line, column };
+    }
+
+    function normalizeErrorReport(value, fallback = 'Unknown error') {
+      const errorValue = value?.error ?? value?.reason ?? value;
+      const message = firstNonEmptyText(
+        value?.message,
+        errorValue?.message,
+        typeof errorValue === 'string' ? errorValue : '',
+        stringifyErrorValue(errorValue),
+        stringifyErrorValue(value),
+        fallback
+      );
+      const stack = firstNonEmptyText(errorValue?.stack, value?.stack);
+      const name = firstNonEmptyText(errorValue?.name, value?.name);
+      const raw = firstNonEmptyText(
+        stringifyErrorValue(errorValue),
+        stringifyErrorValue(value)
+      );
+      return {
+        message,
+        stack,
+        name,
+        raw,
+        location: errorLocation(value),
+      };
+    }
+
     function errorDetail(value, fallback = 'Unknown error') {
-      if (typeof value?.message === 'string' && value.message.length > 0) {
-        return value.message;
+      return normalizeErrorReport(value, fallback).message;
+    }
+
+    function clearErrorReport() {
+      window.orlyErrorReport = null;
+    }
+
+    function captureErrorReport({
+      source,
+      title,
+      status,
+      error,
+      fallback = 'Unknown error',
+    }) {
+      const report = {
+        source: textOrEmpty(source),
+        title: textOrEmpty(title),
+        status: textOrEmpty(status),
+        capturedAt: new Date().toISOString(),
+        ...normalizeErrorReport(error, fallback),
+      };
+      window.orlyErrorReport = report;
+      if (report.status.length > 0) {
+        showStatus(report.status, 'error');
       }
-      if (typeof value === 'string' && value.length > 0) {
-        return value;
-      }
-      return fallback;
+      showPlaceholder(report.title, report.message, 'error');
+      return report;
     }
 
     function showPlaceholder(title, detail = '', state = 'loading') {
@@ -538,11 +630,13 @@
       placeholderTitle.textContent = safeTitle;
       placeholderDetail.textContent = safeDetail;
       placeholderDetail.hidden = safeDetail.length === 0;
+      if (state !== 'error') clearErrorReport();
     }
 
     function hidePlaceholder() {
       gamePlaceholder.hidden = true;
       gamePlaceholder.dataset.state = 'ready';
+      clearErrorReport();
     }
 
     function showStatus(msg, type = 'loading') {
@@ -557,6 +651,8 @@
       statusBar.textContent = '';
     }
 
+    clearErrorReport();
+
     const GAME_TICK_MS = 16;
     const MAX_FRAME_DT_MS = 100;
     const MAX_SIMULATION_STEPS = 6;
@@ -566,13 +662,21 @@
     // JsCoq internal errors that bubble up as uncaught exceptions.
     window.addEventListener('error', (e) => {
       const msg = errorDetail(e);
-      showStatus(`Error: ${msg}`, 'error');
-      showPlaceholder('Browser startup failed', msg, 'error');
+      captureErrorReport({
+        source: 'window-error',
+        title: 'Browser startup failed',
+        status: `Error: ${msg}`,
+        error: e,
+      });
     });
     window.addEventListener('unhandledrejection', (e) => {
       const msg = errorDetail(e.reason);
-      showStatus(`Error: ${msg}`, 'error');
-      showPlaceholder('Browser startup failed', msg, 'error');
+      captureErrorReport({
+        source: 'unhandled-rejection',
+        title: 'Browser startup failed',
+        status: `Error: ${msg}`,
+        error: e,
+      });
     });
 
     // ── asset loader ─────────────────────────────────────────────
@@ -712,8 +816,12 @@
       jscoqOk = true;
     } catch (err) {
       const msg = errorDetail(err);
-      showStatus(`Failed to load JsCoq: ${msg}`, 'error');
-      showPlaceholder('JsCoq startup failed', msg, 'error');
+      captureErrorReport({
+        source: 'jscoq-bootstrap',
+        title: 'JsCoq startup failed',
+        status: `Failed to load JsCoq: ${msg}`,
+        error: err,
+      });
       console.error('JsCoq bootstrap failed:', err);
     }
 
@@ -741,8 +849,12 @@
       console.error('Asset loading failed:', err);
       window.orlyAssets = new Map();
       const msg = errorDetail(err);
-      showPlaceholder('Asset loading failed', msg, 'error');
-      if (jscoqOk) showStatus(`Failed to load assets: ${msg}`, 'error');
+      captureErrorReport({
+        source: 'asset-loading',
+        title: 'Asset loading failed',
+        status: jscoqOk ? `Failed to load assets: ${msg}` : '',
+        error: err,
+      });
     }
 
     // ── game canvas sizing ───────────────────────────────────────
@@ -909,8 +1021,12 @@
       } catch (err) {
         console.error('BSP render init failed:', err);
         const msg = errorDetail(err);
-        showStatus(`Render error: ${msg}`, 'error');
-        showPlaceholder('Render startup failed', msg, 'error');
+        captureErrorReport({
+          source: 'render-startup',
+          title: 'Render startup failed',
+          status: `Render error: ${msg}`,
+          error: err,
+        });
       }
     }
     // ── direction-aware drag-to-resize ───────────────────────────

--- a/scripts/repro-q3dm1-render.mjs
+++ b/scripts/repro-q3dm1-render.mjs
@@ -190,6 +190,8 @@ async function gatherSnapshot(page) {
     const placeholder = document.getElementById('game-placeholder');
     const placeholderTitle = placeholder?.querySelector('[data-placeholder-role="title"]');
     const placeholderDetail = placeholder?.querySelector('[data-placeholder-role="detail"]');
+    const copyButton = placeholder?.querySelector('[data-placeholder-role="copy-button"]');
+    const copyFallback = placeholder?.querySelector('[data-placeholder-role="copy-fallback"]');
     const canvas = document.getElementById('game-canvas');
     const overlay = document.getElementById('game-overlay');
     const main = document.getElementById('main');
@@ -202,6 +204,12 @@ async function gatherSnapshot(page) {
     const desktopHint = document.getElementById('game-hint-desktop');
     const mobileHint = document.getElementById('game-hint-mobile');
     const assetMap = window.orlyAssets instanceof Map ? window.orlyAssets : null;
+    const buildInfo = window.orlyBuildInfo && typeof window.orlyBuildInfo === 'object'
+      ? structuredClone(window.orlyBuildInfo)
+      : null;
+    const errorReport = window.orlyErrorReport && typeof window.orlyErrorReport === 'object'
+      ? structuredClone(window.orlyErrorReport)
+      : null;
 
     function rectOf(element) {
       if (!element) return null;
@@ -261,6 +269,22 @@ async function gatherSnapshot(page) {
             detail: placeholderDetail?.textContent?.trim() ?? '',
           }
         : null,
+      errorCopy: {
+        button: copyButton
+          ? {
+              ...visibilityOf(copyButton),
+              text: copyButton.textContent?.trim() ?? '',
+            }
+          : null,
+        fallback: copyFallback
+          ? {
+              ...visibilityOf(copyFallback),
+              value: copyFallback.value ?? '',
+              selectionStart: copyFallback.selectionStart,
+              selectionEnd: copyFallback.selectionEnd,
+            }
+          : null,
+      },
       canvas: canvas
         ? {
           width: canvas.width,
@@ -301,6 +325,8 @@ async function gatherSnapshot(page) {
         lookPad: rectOf(lookPad),
         jumpButton: rectOf(jumpButton),
       },
+      buildInfo,
+      errorReport,
       assetCount: assetMap?.size ?? null,
       jscoqLoaded: Boolean(document.querySelector('.CodeMirror')),
     };
@@ -622,6 +648,69 @@ function assertMobileRenderStartupScenario(snapshot, consoleEvents, orientation)
   }
 }
 
+function assertErrorOverlayCopyScenario(snapshot, consoleEvents, interactions) {
+  assertNoAssetsScenario(interactions.readySnapshot, consoleEvents);
+
+  const copy = interactions.copyOverlay;
+  if (!copy) {
+    throw new Error('copy overlay diagnostics missing');
+  }
+
+  const errorSnapshot = copy.snapshot ?? snapshot;
+  if (errorSnapshot.placeholder?.state !== 'error') {
+    throw new Error(`expected error placeholder state, got ${errorSnapshot.placeholder?.state ?? '(missing)'}`);
+  }
+  if (errorSnapshot.placeholder?.title !== 'Browser startup failed') {
+    throw new Error(`unexpected error placeholder title: ${errorSnapshot.placeholder?.title ?? '(missing)'}`);
+  }
+  if (!errorSnapshot.placeholder?.detail.includes('Copy smoke error')) {
+    throw new Error(`unexpected error placeholder detail: ${errorSnapshot.placeholder?.detail ?? '(missing)'}`);
+  }
+  if (errorSnapshot.status?.className !== 'error') {
+    throw new Error(`expected status bar error class, got ${errorSnapshot.status?.className ?? '(missing)'}`);
+  }
+  if (!errorSnapshot.status?.text.includes('Copy smoke error')) {
+    throw new Error(`unexpected status bar text: ${errorSnapshot.status?.text ?? '(missing)'}`);
+  }
+  if (!errorSnapshot.errorCopy?.button?.visible) {
+    throw new Error('copy button did not become visible in error state');
+  }
+  if (errorSnapshot.errorCopy?.button?.text !== 'Copy') {
+    throw new Error(`copy button did not reset label: ${errorSnapshot.errorCopy?.button?.text ?? '(missing)'}`);
+  }
+  if (!errorSnapshot.errorCopy?.fallback?.visible) {
+    throw new Error('fallback textarea stayed hidden after clipboard API removal');
+  }
+  if (errorSnapshot.errorCopy?.fallback?.selectionStart !== 0) {
+    throw new Error(`fallback selection start should be 0, got ${errorSnapshot.errorCopy?.fallback?.selectionStart}`);
+  }
+  if (errorSnapshot.errorCopy?.fallback?.selectionEnd !== copy.fallbackText.length) {
+    throw new Error(
+      `fallback selection end should cover full payload, got ${errorSnapshot.errorCopy?.fallback?.selectionEnd}`
+    );
+  }
+
+  if (errorSnapshot.errorReport?.message !== 'Copy smoke error') {
+    throw new Error(`unexpected captured error message: ${errorSnapshot.errorReport?.message ?? '(missing)'}`);
+  }
+  if (errorSnapshot.errorReport?.build?.gitSha !== 'unknown') {
+    throw new Error(`unexpected captured build SHA: ${errorSnapshot.errorReport?.build?.gitSha ?? '(missing)'}`);
+  }
+  if (errorSnapshot.buildInfo?.source !== 'checked-in-default') {
+    throw new Error(`unexpected local build metadata source: ${errorSnapshot.buildInfo?.source ?? '(missing)'}`);
+  }
+
+  if (copy.copiedLabel !== 'Copied!') {
+    throw new Error(`copy button did not show success label: ${copy.copiedLabel}`);
+  }
+  if (copy.resetLabel !== 'Copy') {
+    throw new Error(`copy button did not reset after feedback: ${copy.resetLabel}`);
+  }
+
+  assertClipboardPayload(copy.clipboardText, 'clipboard payload');
+  assertClipboardPayload(copy.fallbackText, 'fallback payload');
+}
+
 async function dragResizeHandle(page, { deltaX = 0, deltaY = 0 }) {
   const handle = page.locator('#resize-handle');
   const box = await handle.boundingBox();
@@ -664,6 +753,84 @@ async function exerciseResizeHandle(page, orientation) {
   return { before, after };
 }
 
+async function exerciseErrorOverlayCopy(page) {
+  await page.evaluate(() => {
+    const error = new Error('Copy smoke error');
+    window.dispatchEvent(new ErrorEvent('error', {
+      message: error.message,
+      error,
+      filename: 'http://example.test/copy.js',
+      lineno: 9,
+      colno: 5,
+    }));
+  });
+
+  const copyButton = page.locator('#copy-error-report');
+  await copyButton.waitFor({ state: 'visible' });
+  await copyButton.click();
+
+  const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+  const copiedLabel = (await copyButton.textContent())?.trim() ?? '';
+  await page.waitForTimeout(1200);
+  const resetLabel = (await copyButton.textContent())?.trim() ?? '';
+
+  await page.evaluate(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: undefined,
+    });
+  });
+  await copyButton.click();
+
+  const fallback = page.locator('#error-copy-fallback');
+  await fallback.waitFor({ state: 'visible' });
+  const fallbackText = await fallback.inputValue();
+  const fallbackSelection = await page.evaluate(() => {
+    const element = document.getElementById('error-copy-fallback');
+    return {
+      start: element?.selectionStart ?? null,
+      end: element?.selectionEnd ?? null,
+    };
+  });
+  const snapshot = await gatherSnapshotWithRetry(page);
+
+  return {
+    clipboardText,
+    copiedLabel,
+    resetLabel,
+    fallbackText,
+    fallbackSelection,
+    snapshot,
+  };
+}
+
+function assertClipboardPayload(text, label = 'clipboard payload') {
+  if (!text.startsWith('```text\n')) {
+    throw new Error(`${label} should start with a fenced code block`);
+  }
+  if (!text.includes('Message: Copy smoke error')) {
+    throw new Error(`${label} missing error message`);
+  }
+  if (!text.includes('Stack trace:\nError: Copy smoke error')) {
+    throw new Error(`${label} missing stack trace`);
+  }
+  if (!text.includes('User agent:')) {
+    throw new Error(`${label} missing user agent`);
+  }
+  if (!text.includes('Page URL: http://127.0.0.1:')) {
+    throw new Error(`${label} missing page URL`);
+  }
+  if (!text.includes('Build git SHA: unknown')) {
+    throw new Error(`${label} missing build SHA`);
+  }
+  if (!text.includes('Build source: checked-in-default')) {
+    throw new Error(`${label} missing build source`);
+  }
+  if (!text.includes('Location: http://example.test/copy.js, line 9, column 5')) {
+    throw new Error(`${label} missing source location`);
+  }
+}
+
 async function runScenario(browser, scenario, outDir, port) {
   const scenarioRoot = scenario.url ? null : await createScenarioRoot(scenario.rootScenario ?? scenario.name);
   const serverInfo = scenario.url ? null : startStaticServer(scenarioRoot, port);
@@ -681,18 +848,24 @@ async function runScenario(browser, scenario, outDir, port) {
     });
 
     context = await browser.newContext(scenario.contextOptions ?? { viewport: { width: 1280, height: 720 } });
+    if (Array.isArray(scenario.permissions) && scenario.permissions.length > 0) {
+      await context.grantPermissions(scenario.permissions, { origin: new URL(url).origin });
+    }
     page = await context.newPage();
     attachEventCapture(page, consoleEvents);
 
     await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 120000 });
     await page.waitForLoadState('load').catch(() => {});
 
-    const snapshot = await waitForScenario(
-      page,
-      consoleEvents,
+    const readyWhen = scenario.readyWhen ?? (
       scenario.name === 'browser-load-no-assets'
         ? current => current.jscoqLoaded && current.status?.hidden === true
         : current => current.placeholder?.hidden === true
+    );
+    const snapshot = await waitForScenario(
+      page,
+      consoleEvents,
+      readyWhen
     );
 
     const extraInteractions = scenario.afterReady
@@ -809,6 +982,21 @@ async function main() {
           },
           assert(snapshot, consoleEvents, interactions) {
             assertMobileRenderStartupScenario(interactions.readySnapshot, consoleEvents, 'landscape');
+          },
+        },
+        {
+          name: 'browser-error-overlay-copy',
+          permissions: ['clipboard-read', 'clipboard-write'],
+          readyWhen(current) {
+            return current.jscoqLoaded && current.status?.hidden === true && current.placeholder?.state === 'idle';
+          },
+          async afterReady(page) {
+            return {
+              copyOverlay: await exerciseErrorOverlayCopy(page),
+            };
+          },
+          assert(snapshot, consoleEvents, interactions) {
+            assertErrorOverlayCopyScenario(snapshot, consoleEvents, interactions);
           },
         }
       );


### PR DESCRIPTION
This PR upgrades the demo's browser error overlay so runtime failures keep their structured report data and deployed build metadata instead of dropping the context needed for bug reports. The remaining work adds the in-overlay copy controls and browser coverage for both the Clipboard API path and the fallback flow.

Fixes #61.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] Add copy stack trace controls to the error overlay <!-- type:spec -->
- [x] Test error overlay copy and clipboard fallback <!-- type:spec -->
- [x] Emit demo build metadata for copied reports <!-- type:spec -->
- [x] Capture structured browser error reports <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->