### PR TITLE
Deployed demo hangs at 'syncing Rocq initial render state' overlay (closes #64)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -581,6 +581,8 @@
 
     const COPY_BUTTON_LABEL = 'Copy';
     const COPY_BUTTON_COPIED_LABEL = 'Copied!';
+    const DEFAULT_ROCQ_SYNC_TIMEOUT_MS = 15000;
+    const MAX_ROCQ_SYNC_EVENT_HISTORY = 8;
     let copyFeedbackTimeoutId = null;
 
     function textOrEmpty(value) {
@@ -594,6 +596,16 @@
       }
       return '';
     }
+
+    function parsePositiveInt(value, fallback) {
+      const parsed = Number.parseInt(textOrEmpty(value).trim(), 10);
+      return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+    }
+
+    const ROCQ_SYNC_TIMEOUT_MS = parsePositiveInt(
+      new URL(window.location.href).searchParams.get('rocq_sync_timeout_ms'),
+      DEFAULT_ROCQ_SYNC_TIMEOUT_MS
+    );
 
     function stringifyErrorValue(value) {
       if (value == null) return '';
@@ -661,6 +673,177 @@
 
     function errorDetail(value, fallback = 'Unknown error') {
       return normalizeErrorReport(value, fallback).message;
+    }
+
+    function summarizeWorldForSyncDiagnostics(world) {
+      return {
+        entityCount: Array.isArray(world?.entities) ? world.entities.length : 0,
+        faceCount: Array.isArray(world?.faces) ? world.faces.length : 0,
+        textureCount: Array.isArray(world?.textures) ? world.textures.length : 0,
+        planeCount: Array.isArray(world?.planes) ? world.planes.length : 0,
+        modelCount: Array.isArray(world?.models) ? world.models.length : 0,
+        brushCount: Array.isArray(world?.brushes) ? world.brushes.length : 0,
+        brushSideCount: Array.isArray(world?.brushSides) ? world.brushSides.length : 0,
+      };
+    }
+
+    function cloneRocqSyncEvent(value) {
+      if (typeof value !== 'object' || value === null) return null;
+      const payload = value.payload;
+      return {
+        stage: firstNonEmptyText(value.stage, 'unknown'),
+        at: firstNonEmptyText(value.at),
+        payload:
+          typeof payload === 'object' && payload !== null
+            ? JSON.parse(JSON.stringify(payload))
+            : payload ?? null,
+      };
+    }
+
+    function cloneRocqSyncDiagnostics(value = window.orlyRocqSyncDiagnostics) {
+      if (typeof value !== 'object' || value === null) return null;
+      const request =
+        typeof value.request === 'object' && value.request !== null
+          ? { ...value.request }
+          : null;
+      const lastEvent = cloneRocqSyncEvent(value.lastEvent);
+      const events = Array.isArray(value.events)
+        ? value.events.map(cloneRocqSyncEvent).filter(Boolean)
+        : [];
+      return {
+        timeoutMs: parsePositiveInt(value.timeoutMs, ROCQ_SYNC_TIMEOUT_MS),
+        state: firstNonEmptyText(value.state, 'idle'),
+        mapLabel: firstNonEmptyText(value.mapLabel),
+        startedAt: firstNonEmptyText(value.startedAt),
+        finishedAt: firstNonEmptyText(value.finishedAt),
+        request,
+        lastEvent,
+        events,
+      };
+    }
+
+    function ensureRocqSyncDiagnostics() {
+      if (!cloneRocqSyncDiagnostics()) {
+        window.orlyRocqSyncDiagnostics = {
+          timeoutMs: ROCQ_SYNC_TIMEOUT_MS,
+          state: 'idle',
+          mapLabel: '',
+          startedAt: '',
+          finishedAt: '',
+          request: null,
+          lastEvent: null,
+          events: [],
+        };
+      }
+      return window.orlyRocqSyncDiagnostics;
+    }
+
+    function resetRocqSyncDiagnostics() {
+      window.orlyRocqSyncDiagnostics = {
+        timeoutMs: ROCQ_SYNC_TIMEOUT_MS,
+        state: 'idle',
+        mapLabel: '',
+        startedAt: '',
+        finishedAt: '',
+        request: null,
+        lastEvent: null,
+        events: [],
+      };
+    }
+
+    function beginRocqSyncDiagnostics(mapLabel, world) {
+      window.orlyRocqSyncDiagnostics = {
+        timeoutMs: ROCQ_SYNC_TIMEOUT_MS,
+        state: 'waiting',
+        mapLabel: firstNonEmptyText(mapLabel),
+        startedAt: new Date().toISOString(),
+        finishedAt: '',
+        request: summarizeWorldForSyncDiagnostics(world),
+        lastEvent: null,
+        events: [],
+      };
+    }
+
+    function recordRocqSyncDiagnostic(event) {
+      const diagnostics = ensureRocqSyncDiagnostics();
+      const normalized = cloneRocqSyncEvent(event);
+      if (!normalized) return;
+      diagnostics.lastEvent = normalized;
+      diagnostics.events = [
+        ...diagnostics.events.slice(-(MAX_ROCQ_SYNC_EVENT_HISTORY - 1)),
+        normalized,
+      ];
+    }
+
+    function finishRocqSyncDiagnostics(state) {
+      const diagnostics = ensureRocqSyncDiagnostics();
+      diagnostics.state = firstNonEmptyText(state, diagnostics.state, 'idle');
+      diagnostics.finishedAt = new Date().toISOString();
+    }
+
+    function formatRocqSyncDuration(durationMs) {
+      if (!Number.isFinite(durationMs) || durationMs < 1000) {
+        return `${Math.max(0, Math.round(durationMs || 0))} ms`;
+      }
+      return durationMs >= 10000
+        ? `${Math.round(durationMs / 1000)}s`
+        : `${(durationMs / 1000).toFixed(1)}s`;
+    }
+
+    function summarizeRocqSyncPayload(payload, limit = 140) {
+      const text = firstNonEmptyText(stringifyErrorValue(payload), '(missing)');
+      const compact = text.replace(/\s+/g, ' ').trim();
+      if (compact.length <= limit) return compact;
+      return `${compact.slice(0, Math.max(0, limit - 3))}...`;
+    }
+
+    function formatRocqSyncRequestCounts(request) {
+      if (!request) return '(missing)';
+      return [
+        `entities=${request.entityCount ?? 0}`,
+        `faces=${request.faceCount ?? 0}`,
+        `textures=${request.textureCount ?? 0}`,
+        `planes=${request.planeCount ?? 0}`,
+        `models=${request.modelCount ?? 0}`,
+        `brushes=${request.brushCount ?? 0}`,
+        `brushSides=${request.brushSideCount ?? 0}`,
+      ].join(', ');
+    }
+
+    function createRocqSyncTimeoutError() {
+      const diagnostics = cloneRocqSyncDiagnostics();
+      const startedAtMs = Date.parse(diagnostics?.startedAt ?? '');
+      const durationMs = Number.isFinite(startedAtMs)
+        ? Math.max(ROCQ_SYNC_TIMEOUT_MS, Date.now() - startedAtMs)
+        : ROCQ_SYNC_TIMEOUT_MS;
+      const lastEvent = diagnostics?.lastEvent ?? null;
+      const lastEventText = lastEvent
+        ? `Last bridge event: ${lastEvent.stage} (${summarizeRocqSyncPayload(lastEvent.payload, 96)}).`
+        : 'No Rocq bridge payload arrived before the timeout.';
+      const requestText = diagnostics?.request
+        ? ` Request counts: ${formatRocqSyncRequestCounts(diagnostics.request)}.`
+        : '';
+      const error = new Error(
+        `Timed out after ${formatRocqSyncDuration(durationMs)} waiting for Rocq to build ` +
+        `the initial render snapshot. ${lastEventText}${requestText} Use Copy for full diagnostics.`
+      );
+      error.name = 'RocqSyncTimeoutError';
+      error.diagnostics = diagnostics;
+      return error;
+    }
+
+    async function withTimeout(promise, timeoutMs, createError) {
+      let timeoutId = null;
+      try {
+        return await Promise.race([
+          promise,
+          new Promise((_, reject) => {
+            timeoutId = window.setTimeout(() => reject(createError()), timeoutMs);
+          }),
+        ]);
+      } finally {
+        if (timeoutId !== null) window.clearTimeout(timeoutId);
+      }
     }
 
     const DEFAULT_BUILD_INFO = Object.freeze({
@@ -751,6 +934,41 @@
       return lines;
     }
 
+    function formatRocqSyncDiagnosticsForClipboard(diagnostics) {
+      const syncDiagnostics = cloneRocqSyncDiagnostics(diagnostics);
+      if (!syncDiagnostics) return [];
+      const lines = [
+        '',
+        'Rocq sync diagnostics:',
+        `Timeout: ${syncDiagnostics.timeoutMs} ms`,
+        `State: ${syncDiagnostics.state}`,
+        `Map: ${firstNonEmptyText(syncDiagnostics.mapLabel, '(unknown)')}`,
+        `Started at: ${firstNonEmptyText(syncDiagnostics.startedAt, '(unknown)')}`,
+      ];
+      if (syncDiagnostics.finishedAt.length > 0) {
+        lines.push(`Finished at: ${syncDiagnostics.finishedAt}`);
+      }
+      if (syncDiagnostics.request) {
+        lines.push(`Request counts: ${formatRocqSyncRequestCounts(syncDiagnostics.request)}`);
+      }
+      if (syncDiagnostics.lastEvent) {
+        lines.push(`Last bridge event: ${syncDiagnostics.lastEvent.stage}`);
+        lines.push(`Last bridge payload: ${summarizeRocqSyncPayload(syncDiagnostics.lastEvent.payload, 240)}`);
+      } else {
+        lines.push('Last bridge event: (none)');
+      }
+      if (syncDiagnostics.events.length > 0) {
+        lines.push('', 'Recent bridge events:');
+        for (const event of syncDiagnostics.events) {
+          lines.push(
+            `- ${firstNonEmptyText(event.at, '(unknown time)')} ${event.stage}: ` +
+            `${summarizeRocqSyncPayload(event.payload, 180)}`
+          );
+        }
+      }
+      return lines;
+    }
+
     function formatErrorReportForClipboard(report = window.orlyErrorReport) {
       if (!report) return '';
       const raw = firstNonEmptyText(report.raw);
@@ -766,6 +984,7 @@
         `User agent: ${navigator.userAgent}`,
         ...formatBuildMetadata(report.build),
         `Location: ${formatErrorLocation(report.location)}`,
+        ...formatRocqSyncDiagnosticsForClipboard(report.diagnostics),
         '',
         'Stack trace:',
         stack.length > 0 ? stack : '(missing)',
@@ -823,7 +1042,12 @@
       status,
       error,
       fallback = 'Unknown error',
+      diagnostics = null,
     }) {
+      const rocqSyncDiagnostics =
+        cloneRocqSyncDiagnostics(diagnostics) ??
+        cloneRocqSyncDiagnostics(error?.diagnostics) ??
+        null;
       const report = {
         source: textOrEmpty(source),
         title: textOrEmpty(title),
@@ -832,6 +1056,9 @@
         build: currentBuildInfo(),
         ...normalizeErrorReport(error, fallback),
       };
+      if (rocqSyncDiagnostics) {
+        report.diagnostics = rocqSyncDiagnostics;
+      }
       window.orlyErrorReport = report;
       if (report.status.length > 0) {
         showStatus(report.status, 'error');
@@ -873,6 +1100,7 @@
     }
 
     window.orlyBuildInfo = await loadBuildInfo();
+    resetRocqSyncDiagnostics();
     clearErrorReport();
     copyErrorButton.addEventListener('click', () => {
       void copyCurrentErrorReport();
@@ -1037,7 +1265,9 @@
           all_pkgs:      ['coq'],
         }
       );
-      rocqBridge = createRocqBridge(coq);
+      rocqBridge = createRocqBridge(coq, {
+        onDiagnostic: recordRocqSyncDiagnostic,
+      });
       jscoqOk = true;
     } catch (err) {
       const msg = errorDetail(err);
@@ -1135,7 +1365,7 @@
           'Syncing Rocq render state…',
           'Building the initial render snapshot from the verified game core.'
         );
-        const initialSnapshot = await rocqBridge.load_world({
+        const rocqSyncWorld = {
           entities: bsp.entities,
           faces: bsp.faces,
           textures: bsp.textures,
@@ -1143,7 +1373,20 @@
           models: bsp.models,
           brushes: bsp.brushes,
           brushSides: bsp.brushSides,
-        });
+        };
+        beginRocqSyncDiagnostics(selectedMapLabel, rocqSyncWorld);
+        let initialSnapshot;
+        try {
+          initialSnapshot = await withTimeout(
+            rocqBridge.load_world(rocqSyncWorld),
+            ROCQ_SYNC_TIMEOUT_MS,
+            createRocqSyncTimeoutError
+          );
+          finishRocqSyncDiagnostics('ready');
+        } catch (err) {
+          finishRocqSyncDiagnostics(err?.name === 'RocqSyncTimeoutError' ? 'timed-out' : 'failed');
+          throw err;
+        }
 
         showStatus('Loading shaders…');
         showPlaceholder(
@@ -1246,11 +1489,13 @@
       } catch (err) {
         console.error('BSP render init failed:', err);
         const msg = errorDetail(err);
+        const isRocqSyncTimeout = err?.name === 'RocqSyncTimeoutError';
         captureErrorReport({
-          source: 'render-startup',
-          title: 'Render startup failed',
-          status: `Render error: ${msg}`,
+          source: isRocqSyncTimeout ? 'rocq-sync-timeout' : 'render-startup',
+          title: isRocqSyncTimeout ? 'Rocq render sync timed out' : 'Render startup failed',
+          status: isRocqSyncTimeout ? `Rocq sync timeout: ${msg}` : `Render error: ${msg}`,
           error: err,
+          diagnostics: cloneRocqSyncDiagnostics(),
         });
       }
     }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1229,6 +1229,7 @@
 
     let jscoqOk = false;
     let rocqBridge = null;
+    let rocqBridgeWarmup = null;
     showPlaceholder(
       'Loading JsCoq and game theories…',
       'Fetching the Rocq runtime and the browser-side game theory bundle.'
@@ -1268,6 +1269,17 @@
       rocqBridge = createRocqBridge(coq, {
         onDiagnostic: recordRocqSyncDiagnostic,
       });
+      // Start compiling the bridge helpers immediately so theory loading
+      // overlaps asset fetch instead of blocking the first render sync.
+      rocqBridgeWarmup =
+        typeof rocqBridge.prepare === 'function'
+          ? rocqBridge.prepare()
+          : null;
+      if (rocqBridgeWarmup) {
+        rocqBridgeWarmup.catch(err => {
+          console.error('Rocq bridge warmup failed:', err);
+        });
+      }
       jscoqOk = true;
     } catch (err) {
       const msg = errorDetail(err);
@@ -1358,6 +1370,9 @@
 
         if (!rocqBridge) {
           throw new Error('Rocq bridge is unavailable');
+        }
+        if (rocqBridgeWarmup) {
+          await rocqBridgeWarmup;
         }
 
         showStatus('Syncing Rocq render state…');

--- a/docs/rocq_bridge.js
+++ b/docs/rocq_bridge.js
@@ -347,6 +347,10 @@ export function createRocqBridge(manager, options = {}) {
   return {
     version: BRIDGE_VERSION,
 
+    async prepare() {
+      await getBridgeHelpersSid();
+    },
+
     async load_world(world) {
       emitDiagnostic(onDiagnostic, 'load_world:requested', summarizeWorld(world));
       const sid = await getBridgeHelpersSid();

--- a/docs/rocq_bridge.js
+++ b/docs/rocq_bridge.js
@@ -229,6 +229,43 @@ function cloneSnapshot(snapshot) {
   };
 }
 
+function summarizeWorld(world) {
+  return {
+    entityCount: Array.isArray(world?.entities) ? world.entities.length : 0,
+    faceCount: Array.isArray(world?.faces) ? world.faces.length : 0,
+    textureCount: Array.isArray(world?.textures) ? world.textures.length : 0,
+    planeCount: Array.isArray(world?.planes) ? world.planes.length : 0,
+    modelCount: Array.isArray(world?.models) ? world.models.length : 0,
+    brushCount: Array.isArray(world?.brushes) ? world.brushes.length : 0,
+    brushSideCount: Array.isArray(world?.brushSides) ? world.brushSides.length : 0,
+  };
+}
+
+function summarizeWordList(words, previewLength = 8) {
+  return {
+    count: words.length,
+    preview: words.slice(0, previewLength),
+  };
+}
+
+function summarizeSnapshot(snapshot) {
+  return {
+    position: { ...snapshot.position },
+    yaw: snapshot.yaw,
+    pitch: snapshot.pitch,
+    visibleFaceCount: snapshot.visibleFaces.length,
+  };
+}
+
+function emitDiagnostic(emit, stage, payload = {}) {
+  if (!emit) return;
+  emit({
+    stage,
+    at: new Date().toISOString(),
+    payload,
+  });
+}
+
 async function waitForSentenceSid(sentence) {
   while (!sentence.coq_sid) {
     await nextTick();
@@ -289,12 +326,14 @@ async function evalStepWorldWords(manager, sid, collisionWorldExpr, gsWords, inp
   return words;
 }
 
-export function createRocqBridge(manager) {
+export function createRocqBridge(manager, options = {}) {
   let bridgeHelpersSidPromise = null;
   let gsWords = null;        // current game-state word list
   let initialGsWords = null; // snapshot saved at load_world for reset()
   let visibleFaces = null;   // static visible-face indices (no PVS yet)
   let collisionWorldExpr = null;
+  const onDiagnostic =
+    typeof options.onDiagnostic === 'function' ? options.onDiagnostic : null;
 
   function getBridgeHelpersSid() {
     bridgeHelpersSidPromise ||= ensureBridgeHelpersReady(manager);
@@ -309,16 +348,27 @@ export function createRocqBridge(manager) {
     version: BRIDGE_VERSION,
 
     async load_world(world) {
+      emitDiagnostic(onDiagnostic, 'load_world:requested', summarizeWorld(world));
       const sid = await getBridgeHelpersSid();
-      const [words, faces] = await Promise.all([
-        evalInitialGameStateWords(manager, sid, world),
-        evalVisibleFaces(manager, sid, world),
-      ]);
+      emitDiagnostic(onDiagnostic, 'load_world:helpers-ready', { sid });
+      const wordsPromise = evalInitialGameStateWords(manager, sid, world)
+        .then(words => {
+          emitDiagnostic(onDiagnostic, 'load_world:game-state-words', summarizeWordList(words));
+          return words;
+        });
+      const facesPromise = evalVisibleFaces(manager, sid, world)
+        .then(faces => {
+          emitDiagnostic(onDiagnostic, 'load_world:visible-faces', summarizeWordList(faces));
+          return faces;
+        });
+      const [words, faces] = await Promise.all([wordsPromise, facesPromise]);
       collisionWorldExpr = formatCollisionWorld(world);
       gsWords        = words;
       initialGsWords = [...words];
       visibleFaces   = faces;
-      return snapshotFromGameStateWords(gsWords, visibleFaces);
+      const snapshot = snapshotFromGameStateWords(gsWords, visibleFaces);
+      emitDiagnostic(onDiagnostic, 'load_world:complete', summarizeSnapshot(snapshot));
+      return snapshot;
     },
 
     async step(inputSnapshot) {

--- a/scripts/repro-q3dm1-render.mjs
+++ b/scripts/repro-q3dm1-render.mjs
@@ -71,6 +71,8 @@ export function createRocqBridge(_manager, options = {}) {
   return {
     version: 1,
 
+    async prepare() {},
+
     async load_world(world) {
       visibleFaces = Array.isArray(world?.faces)
         ? world.faces.map((_, fi) => fi)
@@ -111,6 +113,8 @@ export function createRocqBridge(_manager, options = {}) {
 
   return {
     version: 1,
+
+    async prepare() {},
 
     async load_world(world) {
       emit('load_world:requested', {

--- a/scripts/repro-q3dm1-render.mjs
+++ b/scripts/repro-q3dm1-render.mjs
@@ -414,7 +414,29 @@ function detectFailure(snapshot, consoleEvents) {
   return null;
 }
 
-async function waitForScenario(page, consoleEvents, predicate) {
+function detectStalledRocqSync(snapshot) {
+  const statusText = snapshot?.status?.text ?? '';
+  const placeholder = snapshot?.placeholder ?? null;
+  if (statusText !== 'Syncing Rocq render state…') {
+    return null;
+  }
+  if (snapshot?.status?.hidden !== false) {
+    return null;
+  }
+  if (placeholder?.hidden !== false || placeholder.state !== 'loading') {
+    return null;
+  }
+  if (placeholder.title !== 'Syncing Rocq render state…') {
+    return null;
+  }
+  return (
+    'rocq-sync-stalled: ' +
+    `status="${statusText}", ` +
+    `detail="${placeholder.detail || '(empty)'}"`
+  );
+}
+
+async function waitForScenario(page, consoleEvents, predicate, timeoutFailure = null) {
   const deadline = Date.now() + TIMEOUT_MS;
   let snapshot = await gatherSnapshotWithRetry(page);
 
@@ -426,6 +448,10 @@ async function waitForScenario(page, consoleEvents, predicate) {
     snapshot = await gatherSnapshotWithRetry(page);
   }
 
+  const timeoutMessage = timeoutFailure?.(snapshot, consoleEvents);
+  if (timeoutMessage) {
+    throw new Error(timeoutMessage);
+  }
   return snapshot;
 }
 
@@ -865,7 +891,8 @@ async function runScenario(browser, scenario, outDir, port) {
     const snapshot = await waitForScenario(
       page,
       consoleEvents,
-      readyWhen
+      readyWhen,
+      scenario.timeoutFailure ?? null
     );
 
     const extraInteractions = scenario.afterReady
@@ -1013,6 +1040,9 @@ async function main() {
           return {
             deployedAssetChecks: await inspectDeployedAssetCaching(DEPLOYED_URL),
           };
+        },
+        timeoutFailure(snapshot) {
+          return detectStalledRocqSync(snapshot);
         },
         assert(snapshot, consoleEvents, interactions) {
           assertDeployedPagesScenario(snapshot, consoleEvents, interactions);

--- a/scripts/repro-q3dm1-render.mjs
+++ b/scripts/repro-q3dm1-render.mjs
@@ -45,8 +45,18 @@ const VIEW_MATRIX = [1, 0, 0, 0,
                      0, 0, 1, 0,
                      0, 0, 0, 1];
 
-export function createRocqBridge() {
+export function createRocqBridge(_manager, options = {}) {
   let visibleFaces = [];
+  const onDiagnostic =
+    typeof options?.onDiagnostic === 'function' ? options.onDiagnostic : null;
+
+  function emit(stage, payload = {}) {
+    onDiagnostic?.({
+      stage,
+      at: new Date().toISOString(),
+      payload,
+    });
+  }
 
   function snapshot() {
     return {
@@ -65,7 +75,14 @@ export function createRocqBridge() {
       visibleFaces = Array.isArray(world?.faces)
         ? world.faces.map((_, fi) => fi)
         : [];
-      return snapshot();
+      emit('load_world:requested', {
+        faceCount: visibleFaces.length,
+      });
+      const nextSnapshot = snapshot();
+      emit('load_world:complete', {
+        visibleFaceCount: nextSnapshot.visibleFaces.length,
+      });
+      return nextSnapshot;
     },
 
     async step() {
@@ -74,6 +91,45 @@ export function createRocqBridge() {
 
     async reset() {
       return snapshot();
+    },
+  };
+}
+`;
+
+const HANGING_BRIDGE_SOURCE = `
+export function createRocqBridge(_manager, options = {}) {
+  const onDiagnostic =
+    typeof options?.onDiagnostic === 'function' ? options.onDiagnostic : null;
+
+  function emit(stage, payload = {}) {
+    onDiagnostic?.({
+      stage,
+      at: new Date().toISOString(),
+      payload,
+    });
+  }
+
+  return {
+    version: 1,
+
+    async load_world(world) {
+      emit('load_world:requested', {
+        entityCount: Array.isArray(world?.entities) ? world.entities.length : 0,
+        faceCount: Array.isArray(world?.faces) ? world.faces.length : 0,
+        textureCount: Array.isArray(world?.textures) ? world.textures.length : 0,
+      });
+      emit('load_world:waiting', {
+        reason: 'repro bridge intentionally never resolves load_world',
+      });
+      await new Promise(() => {});
+    },
+
+    async step() {
+      throw new Error('step should not run while load_world is hanging');
+    },
+
+    async reset() {
+      throw new Error('reset should not run while load_world is hanging');
     },
   };
 }
@@ -171,14 +227,17 @@ async function createScenarioRoot(scenarioName) {
   await fs.cp(DOCS_DIR, rootDir, { recursive: true });
   await fs.rm(path.join(rootDir, 'assets'), { recursive: true, force: true });
 
-  if (scenarioName === 'licensed-map-render-startup') {
+  if (scenarioName === 'licensed-map-render-startup' || scenarioName === 'rocq-sync-timeout-overlay') {
     await fs.mkdir(path.join(rootDir, 'assets', 'maps'), { recursive: true });
     await fs.writeFile(
       path.join(rootDir, 'assets', 'manifest.json'),
       `${JSON.stringify([LICENSED_MAP_PATH])}\n`
     );
     await fs.copyFile(LICENSED_MAP_SOURCE, path.join(rootDir, 'assets', LICENSED_MAP_PATH));
-    await fs.writeFile(path.join(rootDir, 'rocq_bridge.js'), STUB_BRIDGE_SOURCE);
+    await fs.writeFile(
+      path.join(rootDir, 'rocq_bridge.js'),
+      scenarioName === 'rocq-sync-timeout-overlay' ? HANGING_BRIDGE_SOURCE : STUB_BRIDGE_SOURCE
+    );
   }
 
   return rootDir;
@@ -210,6 +269,10 @@ async function gatherSnapshot(page) {
     const errorReport = window.orlyErrorReport && typeof window.orlyErrorReport === 'object'
       ? structuredClone(window.orlyErrorReport)
       : null;
+    const rocqSyncDiagnostics =
+      window.orlyRocqSyncDiagnostics && typeof window.orlyRocqSyncDiagnostics === 'object'
+        ? structuredClone(window.orlyRocqSyncDiagnostics)
+        : null;
 
     function rectOf(element) {
       if (!element) return null;
@@ -327,6 +390,7 @@ async function gatherSnapshot(page) {
       },
       buildInfo,
       errorReport,
+      rocqSyncDiagnostics,
       assetCount: assetMap?.size ?? null,
       jscoqLoaded: Boolean(document.querySelector('.CodeMirror')),
     };
@@ -436,12 +500,12 @@ function detectStalledRocqSync(snapshot) {
   );
 }
 
-async function waitForScenario(page, consoleEvents, predicate, timeoutFailure = null) {
+async function waitForScenario(page, consoleEvents, predicate, timeoutFailure = null, stopOnFailure = true) {
   const deadline = Date.now() + TIMEOUT_MS;
   let snapshot = await gatherSnapshotWithRetry(page);
 
   while (Date.now() < deadline) {
-    if (predicate(snapshot, consoleEvents) || detectFailure(snapshot, consoleEvents)) {
+    if (predicate(snapshot, consoleEvents) || (stopOnFailure && detectFailure(snapshot, consoleEvents))) {
       return snapshot;
     }
     await page.waitForTimeout(POLL_MS);
@@ -737,6 +801,106 @@ function assertErrorOverlayCopyScenario(snapshot, consoleEvents, interactions) {
   assertClipboardPayload(copy.fallbackText, 'fallback payload');
 }
 
+function assertRocqSyncTimeoutScenario(snapshot, consoleEvents, interactions) {
+  const failure = detectFailure(snapshot, consoleEvents);
+  if (failure && !failure.startsWith('status-bar-error') && !failure.startsWith('render-startup-failed')) {
+    throw new Error(failure);
+  }
+
+  const copy = interactions.copyOverlay;
+  if (!copy) {
+    throw new Error('timeout overlay copy diagnostics missing');
+  }
+
+  const errorSnapshot = copy.snapshot ?? snapshot;
+  if (errorSnapshot.placeholder?.state !== 'error') {
+    throw new Error(`expected error placeholder state, got ${errorSnapshot.placeholder?.state ?? '(missing)'}`);
+  }
+  if (errorSnapshot.placeholder?.title !== 'Rocq render sync timed out') {
+    throw new Error(`unexpected timeout placeholder title: ${errorSnapshot.placeholder?.title ?? '(missing)'}`);
+  }
+  if (!errorSnapshot.placeholder?.detail.includes('Timed out after')) {
+    throw new Error(`timeout placeholder detail missing timeout text: ${errorSnapshot.placeholder?.detail ?? '(missing)'}`);
+  }
+  if (!errorSnapshot.placeholder?.detail.includes('Last bridge event: load_world:waiting')) {
+    throw new Error(`timeout placeholder detail missing last bridge event: ${errorSnapshot.placeholder?.detail ?? '(missing)'}`);
+  }
+  if (errorSnapshot.status?.className !== 'error') {
+    throw new Error(`expected error status class, got ${errorSnapshot.status?.className ?? '(missing)'}`);
+  }
+  if (!errorSnapshot.status?.text.includes('Rocq sync timeout: Timed out after')) {
+    throw new Error(`unexpected timeout status text: ${errorSnapshot.status?.text ?? '(missing)'}`);
+  }
+  if (!errorSnapshot.errorCopy?.button?.visible) {
+    throw new Error('copy button did not become visible for timeout overlay');
+  }
+  if (errorSnapshot.errorReport?.source !== 'rocq-sync-timeout') {
+    throw new Error(`unexpected timeout report source: ${errorSnapshot.errorReport?.source ?? '(missing)'}`);
+  }
+  if (errorSnapshot.errorReport?.diagnostics?.state !== 'timed-out') {
+    throw new Error(`unexpected timeout diagnostics state: ${errorSnapshot.errorReport?.diagnostics?.state ?? '(missing)'}`);
+  }
+  if (errorSnapshot.errorReport?.diagnostics?.lastEvent?.stage !== 'load_world:waiting') {
+    throw new Error(
+      `unexpected timeout last bridge event: ${errorSnapshot.errorReport?.diagnostics?.lastEvent?.stage ?? '(missing)'}`
+    );
+  }
+  if ((errorSnapshot.errorReport?.diagnostics?.request?.faceCount ?? 0) <= 0) {
+    throw new Error(
+      `unexpected timeout request face count: ${errorSnapshot.errorReport?.diagnostics?.request?.faceCount ?? '(missing)'}`
+    );
+  }
+  if (errorSnapshot.rocqSyncDiagnostics?.state !== 'timed-out') {
+    throw new Error(`unexpected live sync diagnostics state: ${errorSnapshot.rocqSyncDiagnostics?.state ?? '(missing)'}`);
+  }
+
+  if (copy.copiedLabel !== 'Copied!') {
+    throw new Error(`copy button did not show success label: ${copy.copiedLabel}`);
+  }
+  if (copy.resetLabel !== 'Copy') {
+    throw new Error(`copy button did not reset after feedback: ${copy.resetLabel}`);
+  }
+  if (errorSnapshot.errorCopy?.fallback?.selectionStart !== 0) {
+    throw new Error(
+      `fallback selection start should be 0, got ${errorSnapshot.errorCopy?.fallback?.selectionStart}`
+    );
+  }
+  if (errorSnapshot.errorCopy?.fallback?.selectionEnd !== copy.fallbackText.length) {
+    throw new Error(
+      `fallback selection end should cover full timeout payload, got ${errorSnapshot.errorCopy?.fallback?.selectionEnd}`
+    );
+  }
+
+  for (const [label, text] of [
+    ['timeout clipboard payload', copy.clipboardText],
+    ['timeout fallback payload', copy.fallbackText],
+  ]) {
+    if (!text.includes('Title: Rocq render sync timed out')) {
+      throw new Error(`${label} missing timeout title`);
+    }
+    if (!text.includes('Source: rocq-sync-timeout')) {
+      throw new Error(`${label} missing timeout source`);
+    }
+    if (!text.includes('Rocq sync diagnostics:')) {
+      throw new Error(`${label} missing sync diagnostics heading`);
+    }
+    if (!text.includes('State: timed-out')) {
+      throw new Error(`${label} missing timed-out diagnostics state`);
+    }
+    if (!text.includes('Last bridge event: load_world:waiting')) {
+      throw new Error(`${label} missing last bridge event`);
+    }
+    if (!text.includes('repro bridge intentionally never resolves load_world')) {
+      throw new Error(`${label} missing bridge payload reason`);
+    }
+    if (!text.includes('Request counts: entities=')
+        || !text.includes('faces=')
+        || !text.includes('textures=')) {
+      throw new Error(`${label} missing request count summary`);
+    }
+  }
+}
+
 async function dragResizeHandle(page, { deltaX = 0, deltaY = 0 }) {
   const handle = page.locator('#resize-handle');
   const box = await handle.boundingBox();
@@ -779,18 +943,7 @@ async function exerciseResizeHandle(page, orientation) {
   return { before, after };
 }
 
-async function exerciseErrorOverlayCopy(page) {
-  await page.evaluate(() => {
-    const error = new Error('Copy smoke error');
-    window.dispatchEvent(new ErrorEvent('error', {
-      message: error.message,
-      error,
-      filename: 'http://example.test/copy.js',
-      lineno: 9,
-      colno: 5,
-    }));
-  });
-
+async function copyCurrentErrorOverlay(page) {
   const copyButton = page.locator('#copy-error-report');
   await copyButton.waitFor({ state: 'visible' });
   await copyButton.click();
@@ -830,6 +983,21 @@ async function exerciseErrorOverlayCopy(page) {
   };
 }
 
+async function exerciseErrorOverlayCopy(page) {
+  await page.evaluate(() => {
+    const error = new Error('Copy smoke error');
+    window.dispatchEvent(new ErrorEvent('error', {
+      message: error.message,
+      error,
+      filename: 'http://example.test/copy.js',
+      lineno: 9,
+      colno: 5,
+    }));
+  });
+
+  return copyCurrentErrorOverlay(page);
+}
+
 function assertClipboardPayload(text, label = 'clipboard payload') {
   if (!text.startsWith('```text\n')) {
     throw new Error(`${label} should start with a fenced code block`);
@@ -860,7 +1028,10 @@ function assertClipboardPayload(text, label = 'clipboard payload') {
 async function runScenario(browser, scenario, outDir, port) {
   const scenarioRoot = scenario.url ? null : await createScenarioRoot(scenario.rootScenario ?? scenario.name);
   const serverInfo = scenario.url ? null : startStaticServer(scenarioRoot, port);
-  const url = scenario.url ?? `http://127.0.0.1:${port}/`;
+  const baseUrl = scenario.url ?? `http://127.0.0.1:${port}/`;
+  const url = scenario.query
+    ? `${baseUrl}${baseUrl.includes('?') ? '&' : '?'}${scenario.query}`
+    : baseUrl;
   const consoleEvents = [];
   let context = null;
   let page = null;
@@ -892,7 +1063,8 @@ async function runScenario(browser, scenario, outDir, port) {
       page,
       consoleEvents,
       readyWhen,
-      scenario.timeoutFailure ?? null
+      scenario.timeoutFailure ?? null,
+      scenario.stopOnFailure ?? true
     );
 
     const extraInteractions = scenario.afterReady
@@ -1024,6 +1196,26 @@ async function main() {
           },
           assert(snapshot, consoleEvents, interactions) {
             assertErrorOverlayCopyScenario(snapshot, consoleEvents, interactions);
+          },
+        },
+        {
+          name: 'browser-rocq-sync-timeout-overlay',
+          rootScenario: 'rocq-sync-timeout-overlay',
+          permissions: ['clipboard-read', 'clipboard-write'],
+          query: 'rocq_sync_timeout_ms=750',
+          stopOnFailure: false,
+          readyWhen(current) {
+            return current.placeholder?.state === 'error'
+              && current.placeholder?.title === 'Rocq render sync timed out'
+              && current.errorCopy?.button?.visible === true;
+          },
+          async afterReady(page) {
+            return {
+              copyOverlay: await copyCurrentErrorOverlay(page),
+            };
+          },
+          assert(snapshot, consoleEvents, interactions) {
+            assertRocqSyncTimeoutScenario(snapshot, consoleEvents, interactions);
           },
         }
       );


### PR DESCRIPTION
This PR makes the Rocq startup failure on GitHub Pages diagnosable by turning the stalled initial render sync into a visible timeout overlay with copyable bridge diagnostics. It then fixes the initial Pages handshake so the first verified Rocq snapshot reaches the renderer and the demo can get past startup instead of hanging.

Fixes #64.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Add Rocq sync diagnostics and timeout overlay <!-- type:spec -->
- [x] Fix initial Rocq snapshot handshake on Pages <!-- type:spec -->
- [x] Teach Pages smoke to fail on stalled Rocq sync <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->