### PR TITLE
Js lower panel not mobile friendly on GH pages  (closes #66)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -17,6 +17,12 @@
   -->
   <script src="coi-serviceworker.js"></script>
 
+  <!--
+    JsCoq's ESM entrypoint does not auto-attach its frontend stylesheet.
+    Load it explicitly so the IDE panel uses the intended split layout.
+  -->
+  <link rel="stylesheet" href="./vendor/jscoq/dist/frontend/index.css">
+
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -1227,6 +1233,43 @@
       return null;
     }
 
+    const MOBILE_JSCOQ_QUERY = '(pointer: coarse) and (max-width: 1023px)';
+    const mobileJsCoqQuery = window.matchMedia(MOBILE_JSCOQ_QUERY);
+
+    function setJsCoqLogLevel(layout, level) {
+      if (!layout || typeof layout.filterLog !== 'function') return;
+      layout.filterLog(level);
+
+      const select = layout.panel?.querySelector?.('select[name="msg_filter"]');
+      if (!select) return;
+
+      const optionValue = typeof level === 'string'
+        ? layout.log_levels?.indexOf(level)
+        : level;
+      if (Number.isInteger(optionValue) && optionValue >= 0) {
+        select.value = String(optionValue);
+      }
+    }
+
+    function collapseJsCoqFlexPanel(root, selector) {
+      const panel = root.querySelector(selector)?.closest('.flex-panel');
+      if (panel) panel.classList.add('collapsed');
+    }
+
+    function applyMobileJsCoqDefaults(coq) {
+      if (!mobileJsCoqQuery.matches) return;
+
+      const layout = coq?.layout;
+      const panelRoot = layout?.panel;
+      if (!layout || !panelRoot) return;
+
+      layout.hideHelp?.();
+      setJsCoqLogLevel(layout, 0);
+      collapseJsCoqFlexPanel(panelRoot, '#help-panel');
+      collapseJsCoqFlexPanel(panelRoot, '.msg-area');
+      collapseJsCoqFlexPanel(panelRoot, '#packages-panel');
+    }
+
     let jscoqOk = false;
     let rocqBridge = null;
     let rocqBridgeWarmup = null;
@@ -1266,6 +1309,10 @@
           all_pkgs:      ['coq'],
         }
       );
+      applyMobileJsCoqDefaults(coq);
+      coq.when_ready?.then(() => {
+        applyMobileJsCoqDefaults(coq);
+      });
       rocqBridge = createRocqBridge(coq, {
         onDiagnostic: recordRocqSyncDiagnostic,
       });

--- a/docs/index.html
+++ b/docs/index.html
@@ -391,6 +391,190 @@
       height: 100%;
     }
 
+    @media (pointer: coarse) and (max-width: 767px), (orientation: landscape) and (max-height: 560px) {
+      #jscoq-panel {
+        padding:
+          0.55rem
+          max(0.55rem, env(safe-area-inset-right))
+          max(0.7rem, env(safe-area-inset-bottom))
+          max(0.55rem, env(safe-area-inset-left));
+        border-top: none;
+        background: linear-gradient(180deg, rgb(15 20 38 / 98%), rgb(8 11 22 / 98%));
+      }
+
+      #jscoq-panel #ide-wrapper {
+        height: 100%;
+        overflow: hidden;
+        border: 1px solid rgb(160 196 255 / 16%);
+        border-radius: 1rem;
+        background: #f7f9ff;
+        box-shadow: 0 -18px 36px rgb(0 0 0 / 32%);
+      }
+
+      #jscoq-panel #ide-wrapper.layout-flex {
+        flex-direction: column;
+        justify-content: stretch;
+        align-items: stretch;
+      }
+
+      #jscoq-panel #ide-wrapper.layout-flex > *:not(#panel-wrapper):not(#outline-pane):not(.CodeMirror-hints) {
+        width: 100%;
+        min-width: 0;
+      }
+
+      #jscoq-panel #ide-wrapper.layout-flex > #panel-wrapper {
+        flex: 0 0 clamp(8.75rem, 42%, 14rem);
+        width: 100%;
+        max-width: none;
+      }
+
+      #jscoq-panel #panel-wrapper {
+        width: 100%;
+        max-width: none;
+        min-width: 0;
+        border-top: 1px solid #d7deef;
+        border-left: none;
+      }
+
+      #jscoq-panel #document {
+        margin: 0;
+        max-width: none;
+        padding: 0.65rem 0.65rem 0.5rem;
+      }
+
+      #jscoq-panel #document .CodeMirror {
+        margin-bottom: 0;
+        border-radius: 0.75rem;
+        overflow: hidden;
+      }
+
+      #jscoq-panel #toolbar {
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+        height: 42px;
+        padding: 0 0.45rem;
+        border-bottom: 1px solid #d7deef;
+        background: linear-gradient(180deg, #fdfdff, #eef3ff);
+      }
+
+      #jscoq-panel #toolbar .exits {
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+        padding-left: 0;
+      }
+
+      #jscoq-panel #toolbar .exits.right {
+        position: static;
+        top: auto;
+        right: auto;
+        margin-left: auto;
+      }
+
+      #jscoq-panel #toolbar .coq-logo,
+      #jscoq-panel #toolbar .js-logo,
+      #jscoq-panel #toolbar .wa-logo,
+      #jscoq-panel #toolbar .exits > i {
+        display: none;
+      }
+
+      #jscoq-panel #buttons {
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+        margin-top: 0;
+        padding-left: 0;
+      }
+
+      #jscoq-panel #buttons button {
+        width: 28px;
+        height: 28px;
+        border-radius: 0.7rem;
+        background-color: #f7f9ff;
+        background-position: center;
+        background-repeat: no-repeat;
+        background-size: 72%;
+        box-shadow: inset 0 0 0 1px rgb(19 38 79 / 10%);
+      }
+
+      #jscoq-panel #toolbar svg.app-menu-button {
+        width: 30px;
+        height: 30px;
+        padding: 0.2rem;
+        border-radius: 0.7rem;
+        fill: #496492;
+      }
+
+      #jscoq-panel .flex-container {
+        height: calc(100% - 42px);
+      }
+
+      #jscoq-panel .flex-panel > .caption {
+        flex-basis: 28px;
+        min-height: 28px;
+        padding: 0.45rem 1.8rem 0.35rem 0.75rem;
+        font-size: 0.75rem;
+        font-weight: 600;
+        letter-spacing: 0.03em;
+        text-transform: uppercase;
+        background: #e8eef9;
+      }
+
+      #jscoq-panel .flex-panel > .caption:after {
+        top: 6px;
+        right: 9px;
+        border-top-width: 6px;
+        border-right-width: 6px;
+        border-bottom-width: 6px;
+        border-right-color: #6c7ca0;
+      }
+
+      #jscoq-panel .flex-panel > .caption select {
+        margin-left: 0.5rem;
+        font-size: 0.72rem;
+      }
+
+      #jscoq-panel .flex-panel > .content {
+        padding: 0 0.55rem;
+        font-size: 0.8rem;
+        line-height: 1.35;
+      }
+
+      #jscoq-panel #goal-panel:not(.collapsed) {
+        flex-grow: 1200;
+      }
+
+      #jscoq-panel #goal-panel .splash-middle,
+      #jscoq-panel #goal-panel p.system,
+      #jscoq-panel #goal-panel .quick-links {
+        display: none;
+      }
+
+      #jscoq-panel #goal-panel p.splash-above {
+        margin: 0.75rem 0 0;
+        padding: 0 0.75rem;
+        font-size: 0.68rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: #6c7ca0;
+      }
+
+      #jscoq-panel #goal-panel p.splash-below {
+        margin: 0;
+        padding: 0.5rem 0.75rem 0.75rem;
+        font-size: 0.78rem;
+        line-height: 1.4;
+      }
+
+      #jscoq-panel #query-panel > div {
+        padding-left: 1.1rem;
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+        background-size: 12px;
+      }
+    }
+
     /* ══════════════════════════════════════════════════════════
        RESPONSIVE: landscape phone
        Trigger: orientation landscape AND height ≤ 560px.
@@ -1256,6 +1440,14 @@
       if (panel) panel.classList.add('collapsed');
     }
 
+    function reinforceMobileJsCoqDefaults(coq, remainingPasses = 5) {
+      applyMobileJsCoqDefaults(coq);
+      if (remainingPasses <= 1) return;
+      window.setTimeout(() => {
+        reinforceMobileJsCoqDefaults(coq, remainingPasses - 1);
+      }, 150);
+    }
+
     function applyMobileJsCoqDefaults(coq) {
       if (!mobileJsCoqQuery.matches) return;
 
@@ -1309,9 +1501,9 @@
           all_pkgs:      ['coq'],
         }
       );
-      applyMobileJsCoqDefaults(coq);
+      reinforceMobileJsCoqDefaults(coq);
       coq.when_ready?.then(() => {
-        applyMobileJsCoqDefaults(coq);
+        reinforceMobileJsCoqDefaults(coq);
       });
       rocqBridge = createRocqBridge(coq, {
         onDiagnostic: recordRocqSyncDiagnostic,

--- a/scripts/repro-q3dm1-render.mjs
+++ b/scripts/repro-q3dm1-render.mjs
@@ -259,6 +259,14 @@ async function gatherSnapshot(page) {
     const overlay = document.getElementById('game-overlay');
     const main = document.getElementById('main');
     const jscoqPanel = document.getElementById('jscoq-panel');
+    const ideWrapper = document.getElementById('ide-wrapper');
+    const jscoqEditor = document.getElementById('document');
+    const panelWrapper = document.getElementById('panel-wrapper');
+    const toolbar = document.getElementById('toolbar');
+    const goalPanel = document.getElementById('goal-panel');
+    const queryPanel = document.getElementById('query-panel');
+    const packagesPanel = document.getElementById('packages-panel');
+    const helpPanel = document.getElementById('help-panel');
     const resizeHandle = document.getElementById('resize-handle');
     const touchControls = document.getElementById('touch-controls');
     const movePad = document.querySelector('[data-touch-control="move-pad"]');
@@ -310,8 +318,20 @@ async function gatherSnapshot(page) {
       };
     }
 
+    function flexPanelState(element) {
+      if (!element) return null;
+      const panel = element.closest('.flex-panel') ?? element;
+      return {
+        rect: rectOf(element),
+        panelRect: rectOf(panel),
+        className: panel.className,
+        collapsed: panel.classList.contains('collapsed'),
+      };
+    }
+
     const overlayStyle = overlay ? window.getComputedStyle(overlay) : null;
     const mainStyle = main ? window.getComputedStyle(main) : null;
+    const ideWrapperStyle = ideWrapper ? window.getComputedStyle(ideWrapper) : null;
 
     return {
       viewport: {
@@ -375,6 +395,33 @@ async function gatherSnapshot(page) {
       jscoqPanel: jscoqPanel
         ? {
             rect: rectOf(jscoqPanel),
+            ideWrapper: ideWrapper
+              ? {
+                  rect: rectOf(ideWrapper),
+                  display: ideWrapperStyle?.display ?? '',
+                  flexDirection: ideWrapperStyle?.flexDirection ?? '',
+                }
+              : null,
+            editor: jscoqEditor
+              ? {
+                  rect: rectOf(jscoqEditor),
+                }
+              : null,
+            panelWrapper: panelWrapper
+              ? {
+                  rect: rectOf(panelWrapper),
+                }
+              : null,
+            toolbar: toolbar
+              ? {
+                  rect: rectOf(toolbar),
+                  buttonCount: toolbar.querySelectorAll('#buttons button').length,
+                }
+              : null,
+            goalPanel: flexPanelState(goalPanel),
+            queryPanel: flexPanelState(queryPanel),
+            packagesPanel: flexPanelState(packagesPanel),
+            helpPanel: flexPanelState(helpPanel),
           }
         : null,
       resizeHandle: resizeHandle
@@ -688,6 +735,79 @@ function assertTouchTarget(name, rect) {
   }
 }
 
+function assertCollapsedFlexPanel(name, panel) {
+  if (!panel) {
+    throw new Error(`${name} diagnostics missing`);
+  }
+  if (!panel.collapsed) {
+    throw new Error(`${name} should start collapsed on mobile`);
+  }
+  if ((panel.rect?.height ?? 0) > 2) {
+    throw new Error(`${name} content stayed open on mobile`);
+  }
+}
+
+function assertMobileLowerPanelUsability(snapshot, orientation) {
+  const jscoqPanel = snapshot.jscoqPanel;
+  const panelRect = jscoqPanel?.rect;
+  const layout = jscoqPanel?.ideWrapper;
+  const editorRect = jscoqPanel?.editor?.rect;
+  const panelWrapperRect = jscoqPanel?.panelWrapper?.rect;
+  const toolbar = jscoqPanel?.toolbar;
+  const toolbarRect = toolbar?.rect;
+  const goalPanel = jscoqPanel?.goalPanel;
+
+  if (!panelRect || !layout || !editorRect || !panelWrapperRect || !toolbarRect || !goalPanel?.rect) {
+    throw new Error('mobile lower-panel diagnostics missing');
+  }
+
+  if (layout.display !== 'flex' || layout.flexDirection !== 'column') {
+    throw new Error(
+      `mobile lower panel should stack beneath the editor, got ${layout.display}/${layout.flexDirection}`
+    );
+  }
+
+  if (panelWrapperRect.top < layout.rect.top + layout.rect.height * 0.35) {
+    throw new Error('mobile lower panel did not move into the lower portion of the card');
+  }
+
+  if (panelWrapperRect.width < panelRect.width * 0.8) {
+    throw new Error('mobile lower panel lost too much horizontal space');
+  }
+
+  if (Math.abs(panelWrapperRect.width - editorRect.width) > 24) {
+    throw new Error('mobile lower panel width drifted too far from the editor width');
+  }
+
+  if (panelWrapperRect.height < 96) {
+    throw new Error('mobile lower panel became too short to be useful');
+  }
+
+  const maxPanelFraction = orientation === 'portrait' ? 0.72 : 0.6;
+  if (panelWrapperRect.height > panelRect.height * maxPanelFraction) {
+    throw new Error(`${orientation} lower panel consumed too much of the phone panel`);
+  }
+
+  if (toolbarRect.height < 28 || toolbarRect.height > 52) {
+    throw new Error(`mobile lower-panel toolbar height is out of bounds: ${toolbarRect.height}`);
+  }
+
+  if ((toolbar.buttonCount ?? 0) < 4) {
+    throw new Error('mobile lower-panel toolbar is missing core controls');
+  }
+
+  if (goalPanel.rect.height < 44) {
+    throw new Error('mobile lower-panel goal area became too small to read');
+  }
+
+  assertCollapsedFlexPanel('mobile message panel', jscoqPanel.queryPanel);
+  assertCollapsedFlexPanel('mobile packages panel', jscoqPanel.packagesPanel);
+
+  if (!jscoqPanel.helpPanel?.collapsed) {
+    throw new Error('mobile help panel should start collapsed');
+  }
+}
+
 function assertMobileRenderStartupScenario(snapshot, consoleEvents, orientation) {
   assertRenderStartupScenario(snapshot, consoleEvents);
   if (!snapshot.pointer?.coarse) {
@@ -740,6 +860,8 @@ function assertMobileRenderStartupScenario(snapshot, consoleEvents, orientation)
       throw new Error('landscape canvas became too narrow for playability');
     }
   }
+
+  assertMobileLowerPanelUsability(snapshot, orientation);
 }
 
 function assertErrorOverlayCopyScenario(snapshot, consoleEvents, interactions) {


### PR DESCRIPTION
This follows the mobile JsCoq cleanup by restyling the lower panel so the embedded editor and proof panes work cleanly on both portrait and landscape phones. It also extends the Playwright browser checks so GitHub Pages catches mobile lower-panel regressions early.

Fixes #66.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Restyle the lower panel for portrait and landscape phones <!-- type:spec -->
- [x] Extend Playwright coverage for mobile lower-panel usability <!-- type:spec -->
- [x] Trim JsCoq mobile defaults and collapse noisy panels <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->