### PR TITLE
gh pages still broken (closes #67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,16 +90,18 @@ npm run playwright:install
 npm run test:q3dm1-browser
 ```
 
-The regression script runs four scenarios against the local browser build:
+The regression script runs five scenarios against the local browser build:
 
 1. the assetless page load path, to ensure the JsCoq worker bootstrap still
    succeeds without tripping over browser security restrictions
 2. a desktop startup path using a fetched/cached `maps/am_lavaarena.bsp`
    licensed-map asset, to ensure the Rocq-seeded render pipeline reaches its
    first frame and hides the placeholder
-3. an iPhone-sized portrait startup path, to ensure the mobile controls stay
+3. a real-bridge parse handoff path using the licensed BSP, to ensure the page
+   leaves the BSP parsing overlay and enters Rocq sync once decode completes
+4. an iPhone-sized portrait startup path, to ensure the mobile controls stay
    visible, large enough to use, and safely inside the viewport
-4. an iPhone-sized landscape startup path, to ensure the split layout, control
+5. an iPhone-sized landscape startup path, to ensure the split layout, control
    reachability, and touch resize handle remain usable after rotation
 
 It writes screenshots plus JSON diagnostics under your system temp directory.

--- a/docs/bsp.js
+++ b/docs/bsp.js
@@ -7,7 +7,7 @@
 //
 // Usage:
 //   import { parseBsp } from './bsp.js';
-//   const bsp = parseBsp(arrayBuffer);  // throws on invalid input
+//   const bsp = parseBsp(arrayBuffer, { onDiagnostic });  // throws on invalid input
 
 // ── constants ────────────────────────────────────────────────────────
 const BSP_MAGIC   = 0x49425350;  // "IBSP" as stored in the file header
@@ -47,6 +47,61 @@ const LIGHTMAP_SIZE   = 49152;  // 128 * 128 * 3
 const MODEL_SIZE      = 40;
 
 // ── lump directory ───────────────────────────────────────────────────
+
+function nowMs() {
+  if (typeof globalThis.performance?.now === 'function') {
+    return globalThis.performance.now();
+  }
+  return Date.now();
+}
+
+function roundDurationMs(durationMs) {
+  return Number.isFinite(durationMs)
+    ? Math.round(durationMs * 1000) / 1000
+    : 0;
+}
+
+function emitParseDiagnostic(onDiagnostic, stage, payload = null) {
+  if (typeof onDiagnostic !== 'function') return;
+  const normalizedPayload =
+    typeof payload === 'object' && payload !== null
+      ? JSON.parse(JSON.stringify(payload))
+      : payload ?? null;
+  onDiagnostic({
+    stage,
+    at: new Date().toISOString(),
+    payload: normalizedPayload,
+  });
+}
+
+function timeParseStep(onDiagnostic, stage, payload, reader, summarizeResult = () => null) {
+  const startedAtMs = nowMs();
+  emitParseDiagnostic(onDiagnostic, `${stage}:start`, payload);
+  try {
+    const result = reader();
+    emitParseDiagnostic(onDiagnostic, `${stage}:complete`, {
+      ...(payload ?? {}),
+      durationMs: roundDurationMs(nowMs() - startedAtMs),
+      ...(summarizeResult(result) ?? {}),
+    });
+    return result;
+  } catch (error) {
+    emitParseDiagnostic(onDiagnostic, `${stage}:failed`, {
+      ...(payload ?? {}),
+      durationMs: roundDurationMs(nowMs() - startedAtMs),
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+}
+
+function summarizeLump(entry, entrySize = 0) {
+  return {
+    offset: Number.isInteger(entry?.offset) ? entry.offset : 0,
+    byteLength: Number.isInteger(entry?.length) ? entry.length : 0,
+    count: entrySize > 0 ? lumpCount(entry, entrySize) : 0,
+  };
+}
 
 function readLumpDirectory(view) {
   const dir = new Array(NUM_LUMPS);
@@ -410,49 +465,264 @@ export function isVisibleTexture(tex) {
  * (theories/BspFile.v).  Throws on invalid magic or version.
  *
  * @param {ArrayBuffer} buffer
+ * @param {{ onDiagnostic?: Function }} options
  * @returns {object} Parsed BSP data
  */
-export function parseBsp(buffer) {
+export function parseBsp(buffer, options = {}) {
+  const onDiagnostic =
+    typeof options?.onDiagnostic === 'function' ? options.onDiagnostic : null;
+  const parseStartedAtMs = nowMs();
+  emitParseDiagnostic(onDiagnostic, 'parse:start', {
+    byteLength: buffer?.byteLength ?? 0,
+  });
+
   if (buffer.byteLength < 8 + NUM_LUMPS * 8) {
     throw new Error(`BSP too short: ${buffer.byteLength} bytes (need at least ${8 + NUM_LUMPS * 8})`);
   }
 
-  const view = new DataView(buffer);
+  try {
+    const view = new DataView(buffer);
 
-  // Validate header — matches BspFormat.v parse_bsp_header
-  const magic   = view.getUint32(0, false);
-  const version = view.getInt32(4, true);
-  if (magic !== BSP_MAGIC) {
-    throw new Error(`Bad BSP magic: 0x${magic.toString(16)} (expected 0x${BSP_MAGIC.toString(16)})`);
+    const { magic, version } = timeParseStep(
+      onDiagnostic,
+      'header',
+      { byteLength: 8 + NUM_LUMPS * 8 },
+      () => {
+        // Validate header — matches BspFormat.v parse_bsp_header
+        const magic = view.getUint32(0, false);
+        const version = view.getInt32(4, true);
+        if (magic !== BSP_MAGIC) {
+          throw new Error(`Bad BSP magic: 0x${magic.toString(16)} (expected 0x${BSP_MAGIC.toString(16)})`);
+        }
+        if (version !== BSP_VERSION) {
+          throw new Error(`Bad BSP version: ${version} (expected ${BSP_VERSION})`);
+        }
+        return { magic, version };
+      },
+      ({ magic, version }) => ({
+        magic: `0x${magic.toString(16)}`,
+        version,
+      })
+    );
+
+    const dir = timeParseStep(
+      onDiagnostic,
+      'directory',
+      { entryCount: NUM_LUMPS },
+      () => readLumpDirectory(view),
+      directory => ({
+        totalByteLength: directory.reduce((total, entry) => total + Math.max(0, entry?.length ?? 0), 0),
+      })
+    );
+
+    const entityString = timeParseStep(
+      onDiagnostic,
+      'lump:entities:text',
+      summarizeLump(dir[LUMP_ENTITIES]),
+      () => readEntities(view, dir[LUMP_ENTITIES]),
+      value => ({
+        charCount: typeof value === 'string' ? value.length : 0,
+      })
+    );
+
+    const entities = timeParseStep(
+      onDiagnostic,
+      'lump:entities:parse',
+      {
+        charCount: typeof entityString === 'string' ? entityString.length : 0,
+      },
+      () => parseEntities(entityString),
+      value => ({
+        count: Array.isArray(value) ? value.length : 0,
+      })
+    );
+
+    const textures = timeParseStep(
+      onDiagnostic,
+      'lump:textures',
+      summarizeLump(dir[LUMP_TEXTURES], TEXTURE_SIZE),
+      () => readTextures(view, dir[LUMP_TEXTURES]),
+      value => ({
+        count: Array.isArray(value) ? value.length : 0,
+      })
+    );
+    const planes = timeParseStep(
+      onDiagnostic,
+      'lump:planes',
+      summarizeLump(dir[LUMP_PLANES], PLANE_SIZE),
+      () => readPlanes(view, dir[LUMP_PLANES]),
+      value => ({
+        count: Array.isArray(value) ? value.length : 0,
+      })
+    );
+    const nodes = timeParseStep(
+      onDiagnostic,
+      'lump:nodes',
+      summarizeLump(dir[LUMP_NODES], NODE_SIZE),
+      () => readNodes(view, dir[LUMP_NODES]),
+      value => ({
+        count: Array.isArray(value) ? value.length : 0,
+      })
+    );
+    const leaves = timeParseStep(
+      onDiagnostic,
+      'lump:leaves',
+      summarizeLump(dir[LUMP_LEAVES], LEAF_SIZE),
+      () => readLeaves(view, dir[LUMP_LEAVES]),
+      value => ({
+        count: Array.isArray(value) ? value.length : 0,
+      })
+    );
+    const leafFaces = timeParseStep(
+      onDiagnostic,
+      'lump:leaf-faces',
+      summarizeLump(dir[LUMP_LEAF_FACES], 4),
+      () => readI32Lump(view, dir[LUMP_LEAF_FACES]),
+      value => ({
+        count: value?.length ?? 0,
+      })
+    );
+    const leafBrushes = timeParseStep(
+      onDiagnostic,
+      'lump:leaf-brushes',
+      summarizeLump(dir[LUMP_LEAF_BRUSHES], 4),
+      () => readI32Lump(view, dir[LUMP_LEAF_BRUSHES]),
+      value => ({
+        count: value?.length ?? 0,
+      })
+    );
+    const models = timeParseStep(
+      onDiagnostic,
+      'lump:models',
+      summarizeLump(dir[LUMP_MODELS], MODEL_SIZE),
+      () => readModels(view, dir[LUMP_MODELS]),
+      value => ({
+        count: Array.isArray(value) ? value.length : 0,
+      })
+    );
+    const brushes = timeParseStep(
+      onDiagnostic,
+      'lump:brushes',
+      summarizeLump(dir[LUMP_BRUSHES], BRUSH_SIZE),
+      () => readBrushes(view, dir[LUMP_BRUSHES]),
+      value => ({
+        count: Array.isArray(value) ? value.length : 0,
+      })
+    );
+    const brushSides = timeParseStep(
+      onDiagnostic,
+      'lump:brush-sides',
+      summarizeLump(dir[LUMP_BRUSH_SIDES], BRUSH_SIDE_SIZE),
+      () => readBrushSides(view, dir[LUMP_BRUSH_SIDES]),
+      value => ({
+        count: Array.isArray(value) ? value.length : 0,
+      })
+    );
+    const vertices = timeParseStep(
+      onDiagnostic,
+      'lump:vertices',
+      summarizeLump(dir[LUMP_VERTEXES], VERTEX_SIZE),
+      () => readVertices(view, dir[LUMP_VERTEXES]),
+      value => ({
+        count: Array.isArray(value) ? value.length : 0,
+      })
+    );
+    const meshVerts = timeParseStep(
+      onDiagnostic,
+      'lump:mesh-verts',
+      summarizeLump(dir[LUMP_MESH_VERTS], 4),
+      () => readI32Lump(view, dir[LUMP_MESH_VERTS]),
+      value => ({
+        count: value?.length ?? 0,
+      })
+    );
+    const effects = timeParseStep(
+      onDiagnostic,
+      'lump:effects',
+      summarizeLump(dir[LUMP_EFFECTS], EFFECT_SIZE),
+      () => readEffects(view, dir[LUMP_EFFECTS]),
+      value => ({
+        count: Array.isArray(value) ? value.length : 0,
+      })
+    );
+    const faces = timeParseStep(
+      onDiagnostic,
+      'lump:faces',
+      summarizeLump(dir[LUMP_FACES], FACE_SIZE),
+      () => readFaces(view, dir[LUMP_FACES]),
+      value => ({
+        count: Array.isArray(value) ? value.length : 0,
+      })
+    );
+    const lightmaps = timeParseStep(
+      onDiagnostic,
+      'lump:lightmaps',
+      summarizeLump(dir[LUMP_LIGHTMAPS], LIGHTMAP_SIZE),
+      () => readLightmaps(view, dir[LUMP_LIGHTMAPS]),
+      value => ({
+        count: Array.isArray(value) ? value.length : 0,
+      })
+    );
+    const visData = timeParseStep(
+      onDiagnostic,
+      'lump:vis-data',
+      summarizeLump(dir[LUMP_VIS_DATA]),
+      () => readVisData(view, dir[LUMP_VIS_DATA]),
+      value => ({
+        clusterCount: Number.isInteger(value?.numClusters) ? value.numClusters : 0,
+        bytesPerCluster: Number.isInteger(value?.bytesPerCluster) ? value.bytesPerCluster : 0,
+      })
+    );
+
+    const bsp = {
+      magic,
+      version,
+      directory: dir,
+      entities,
+      entityString,
+      textures,
+      planes,
+      nodes,
+      leaves,
+      leafFaces,
+      leafBrushes,
+      models,
+      brushes,
+      brushSides,
+      vertices,
+      meshVerts,
+      effects,
+      faces,
+      lightmaps,
+      visData,
+    };
+
+    emitParseDiagnostic(onDiagnostic, 'parse:complete', {
+      byteLength: buffer.byteLength,
+      durationMs: roundDurationMs(nowMs() - parseStartedAtMs),
+      entityCount: bsp.entities.length,
+      textureCount: bsp.textures.length,
+      planeCount: bsp.planes.length,
+      nodeCount: bsp.nodes.length,
+      leafCount: bsp.leaves.length,
+      modelCount: bsp.models.length,
+      brushCount: bsp.brushes.length,
+      brushSideCount: bsp.brushSides.length,
+      vertexCount: bsp.vertices.length,
+      meshVertCount: bsp.meshVerts.length,
+      effectCount: bsp.effects.length,
+      faceCount: bsp.faces.length,
+      lightmapCount: bsp.lightmaps.length,
+      visClusterCount: Number.isInteger(bsp.visData?.numClusters) ? bsp.visData.numClusters : 0,
+    });
+
+    return bsp;
+  } catch (error) {
+    emitParseDiagnostic(onDiagnostic, 'parse:failed', {
+      byteLength: buffer.byteLength,
+      durationMs: roundDurationMs(nowMs() - parseStartedAtMs),
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
   }
-  if (version !== BSP_VERSION) {
-    throw new Error(`Bad BSP version: ${version} (expected ${BSP_VERSION})`);
-  }
-
-  const dir = readLumpDirectory(view);
-
-  const entityString = readEntities(view, dir[LUMP_ENTITIES]);
-
-  return {
-    magic,
-    version,
-    directory: dir,
-    entities:    parseEntities(entityString),
-    entityString,
-    textures:    readTextures(view, dir[LUMP_TEXTURES]),
-    planes:      readPlanes(view, dir[LUMP_PLANES]),
-    nodes:       readNodes(view, dir[LUMP_NODES]),
-    leaves:      readLeaves(view, dir[LUMP_LEAVES]),
-    leafFaces:   readI32Lump(view, dir[LUMP_LEAF_FACES]),
-    leafBrushes: readI32Lump(view, dir[LUMP_LEAF_BRUSHES]),
-    models:      readModels(view, dir[LUMP_MODELS]),
-    brushes:     readBrushes(view, dir[LUMP_BRUSHES]),
-    brushSides:  readBrushSides(view, dir[LUMP_BRUSH_SIDES]),
-    vertices:    readVertices(view, dir[LUMP_VERTEXES]),
-    meshVerts:   readI32Lump(view, dir[LUMP_MESH_VERTS]),
-    effects:     readEffects(view, dir[LUMP_EFFECTS]),
-    faces:       readFaces(view, dir[LUMP_FACES]),
-    lightmaps:   readLightmaps(view, dir[LUMP_LIGHTMAPS]),
-    visData:     readVisData(view, dir[LUMP_VIS_DATA]),
-  };
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -772,6 +772,7 @@
     const COPY_BUTTON_LABEL = 'Copy';
     const COPY_BUTTON_COPIED_LABEL = 'Copied!';
     const DEFAULT_ROCQ_SYNC_TIMEOUT_MS = 15000;
+    const MAX_BSP_PARSE_EVENT_HISTORY = 24;
     const MAX_ROCQ_SYNC_EVENT_HISTORY = 8;
     let copyFeedbackTimeoutId = null;
 
@@ -863,6 +864,168 @@
 
     function errorDetail(value, fallback = 'Unknown error') {
       return normalizeErrorReport(value, fallback).message;
+    }
+
+    function summarizeBspForParseDiagnostics(bsp) {
+      return {
+        entityCount: Array.isArray(bsp?.entities) ? bsp.entities.length : 0,
+        textureCount: Array.isArray(bsp?.textures) ? bsp.textures.length : 0,
+        planeCount: Array.isArray(bsp?.planes) ? bsp.planes.length : 0,
+        nodeCount: Array.isArray(bsp?.nodes) ? bsp.nodes.length : 0,
+        leafCount: Array.isArray(bsp?.leaves) ? bsp.leaves.length : 0,
+        modelCount: Array.isArray(bsp?.models) ? bsp.models.length : 0,
+        brushCount: Array.isArray(bsp?.brushes) ? bsp.brushes.length : 0,
+        brushSideCount: Array.isArray(bsp?.brushSides) ? bsp.brushSides.length : 0,
+        vertexCount: Array.isArray(bsp?.vertices) ? bsp.vertices.length : 0,
+        meshVertCount: Number.isInteger(bsp?.meshVerts?.length) ? bsp.meshVerts.length : 0,
+        effectCount: Array.isArray(bsp?.effects) ? bsp.effects.length : 0,
+        faceCount: Array.isArray(bsp?.faces) ? bsp.faces.length : 0,
+        lightmapCount: Array.isArray(bsp?.lightmaps) ? bsp.lightmaps.length : 0,
+        visClusterCount: Number.isInteger(bsp?.visData?.numClusters) ? bsp.visData.numClusters : 0,
+      };
+    }
+
+    function cloneBspParseEvent(value) {
+      if (typeof value !== 'object' || value === null) return null;
+      const payload = value.payload;
+      return {
+        stage: firstNonEmptyText(value.stage, 'unknown'),
+        at: firstNonEmptyText(value.at),
+        payload:
+          typeof payload === 'object' && payload !== null
+            ? JSON.parse(JSON.stringify(payload))
+            : payload ?? null,
+      };
+    }
+
+    function cloneBspParseDiagnostics(value = window.orlyBspParseDiagnostics) {
+      if (typeof value !== 'object' || value === null) return null;
+      const summary =
+        typeof value.summary === 'object' && value.summary !== null
+          ? { ...value.summary }
+          : null;
+      const lastEvent = cloneBspParseEvent(value.lastEvent);
+      const events = Array.isArray(value.events)
+        ? value.events.map(cloneBspParseEvent).filter(Boolean)
+        : [];
+      return {
+        state: firstNonEmptyText(value.state, 'idle'),
+        mapLabel: firstNonEmptyText(value.mapLabel),
+        bufferByteLength: Number.isFinite(value.bufferByteLength)
+          ? Math.max(0, Math.round(value.bufferByteLength))
+          : 0,
+        startedAt: firstNonEmptyText(value.startedAt),
+        finishedAt: firstNonEmptyText(value.finishedAt),
+        totalDurationMs: Number.isFinite(value.totalDurationMs) ? value.totalDurationMs : null,
+        summary,
+        lastEvent,
+        events,
+      };
+    }
+
+    function ensureBspParseDiagnostics() {
+      if (!cloneBspParseDiagnostics()) {
+        window.orlyBspParseDiagnostics = {
+          state: 'idle',
+          mapLabel: '',
+          bufferByteLength: 0,
+          startedAt: '',
+          finishedAt: '',
+          totalDurationMs: null,
+          summary: null,
+          lastEvent: null,
+          events: [],
+        };
+      }
+      return window.orlyBspParseDiagnostics;
+    }
+
+    function resetBspParseDiagnostics() {
+      window.orlyBspParseDiagnostics = {
+        state: 'idle',
+        mapLabel: '',
+        bufferByteLength: 0,
+        startedAt: '',
+        finishedAt: '',
+        totalDurationMs: null,
+        summary: null,
+        lastEvent: null,
+        events: [],
+      };
+    }
+
+    function beginBspParseDiagnostics(mapLabel, buffer) {
+      window.orlyBspParseDiagnostics = {
+        state: 'parsing',
+        mapLabel: firstNonEmptyText(mapLabel),
+        bufferByteLength: Number.isFinite(buffer?.byteLength) ? buffer.byteLength : 0,
+        startedAt: new Date().toISOString(),
+        finishedAt: '',
+        totalDurationMs: null,
+        summary: null,
+        lastEvent: null,
+        events: [],
+      };
+    }
+
+    function recordBspParseDiagnostic(event) {
+      const diagnostics = ensureBspParseDiagnostics();
+      const normalized = cloneBspParseEvent(event);
+      if (!normalized) return;
+      diagnostics.lastEvent = normalized;
+      diagnostics.events = [
+        ...diagnostics.events.slice(-(MAX_BSP_PARSE_EVENT_HISTORY - 1)),
+        normalized,
+      ];
+      const durationMs = normalized.payload?.durationMs;
+      if (Number.isFinite(durationMs) &&
+          (normalized.stage === 'parse:complete' || normalized.stage === 'parse:failed')) {
+        diagnostics.totalDurationMs = durationMs;
+      }
+      if (normalized.stage === 'parse:complete') {
+        diagnostics.summary = {
+          entityCount: normalized.payload?.entityCount ?? 0,
+          textureCount: normalized.payload?.textureCount ?? 0,
+          planeCount: normalized.payload?.planeCount ?? 0,
+          nodeCount: normalized.payload?.nodeCount ?? 0,
+          leafCount: normalized.payload?.leafCount ?? 0,
+          modelCount: normalized.payload?.modelCount ?? 0,
+          brushCount: normalized.payload?.brushCount ?? 0,
+          brushSideCount: normalized.payload?.brushSideCount ?? 0,
+          vertexCount: normalized.payload?.vertexCount ?? 0,
+          meshVertCount: normalized.payload?.meshVertCount ?? 0,
+          effectCount: normalized.payload?.effectCount ?? 0,
+          faceCount: normalized.payload?.faceCount ?? 0,
+          lightmapCount: normalized.payload?.lightmapCount ?? 0,
+          visClusterCount: normalized.payload?.visClusterCount ?? 0,
+        };
+      }
+    }
+
+    function finishBspParseDiagnostics(state, bsp = null) {
+      const diagnostics = ensureBspParseDiagnostics();
+      diagnostics.state = firstNonEmptyText(state, diagnostics.state, 'idle');
+      diagnostics.finishedAt = new Date().toISOString();
+      if (bsp) diagnostics.summary = summarizeBspForParseDiagnostics(bsp);
+      if (!Number.isFinite(diagnostics.totalDurationMs)) {
+        const startedAtMs = Date.parse(diagnostics.startedAt);
+        if (Number.isFinite(startedAtMs)) {
+          diagnostics.totalDurationMs = Math.max(0, Date.now() - startedAtMs);
+        }
+      }
+    }
+
+    function hasMeaningfulBspParseDiagnostics(diagnostics) {
+      return Boolean(
+        diagnostics &&
+        (
+          diagnostics.state !== 'idle' ||
+          diagnostics.startedAt.length > 0 ||
+          diagnostics.finishedAt.length > 0 ||
+          diagnostics.events.length > 0 ||
+          diagnostics.summary !== null
+        )
+      );
     }
 
     function summarizeWorldForSyncDiagnostics(world) {
@@ -997,6 +1160,26 @@
         `models=${request.modelCount ?? 0}`,
         `brushes=${request.brushCount ?? 0}`,
         `brushSides=${request.brushSideCount ?? 0}`,
+      ].join(', ');
+    }
+
+    function formatBspParseSummary(summary) {
+      if (!summary) return '(missing)';
+      return [
+        `entities=${summary.entityCount ?? 0}`,
+        `textures=${summary.textureCount ?? 0}`,
+        `planes=${summary.planeCount ?? 0}`,
+        `nodes=${summary.nodeCount ?? 0}`,
+        `leaves=${summary.leafCount ?? 0}`,
+        `models=${summary.modelCount ?? 0}`,
+        `brushes=${summary.brushCount ?? 0}`,
+        `brushSides=${summary.brushSideCount ?? 0}`,
+        `vertices=${summary.vertexCount ?? 0}`,
+        `meshVerts=${summary.meshVertCount ?? 0}`,
+        `effects=${summary.effectCount ?? 0}`,
+        `faces=${summary.faceCount ?? 0}`,
+        `lightmaps=${summary.lightmapCount ?? 0}`,
+        `visClusters=${summary.visClusterCount ?? 0}`,
       ].join(', ');
     }
 
@@ -1159,6 +1342,44 @@
       return lines;
     }
 
+    function formatBspParseDiagnosticsForClipboard(diagnostics) {
+      const parseDiagnostics = cloneBspParseDiagnostics(diagnostics);
+      if (!hasMeaningfulBspParseDiagnostics(parseDiagnostics)) return [];
+      const lines = [
+        '',
+        'BSP parse diagnostics:',
+        `State: ${parseDiagnostics.state}`,
+        `Map: ${firstNonEmptyText(parseDiagnostics.mapLabel, '(unknown)')}`,
+        `Input bytes: ${parseDiagnostics.bufferByteLength}`,
+        `Started at: ${firstNonEmptyText(parseDiagnostics.startedAt, '(unknown)')}`,
+      ];
+      if (parseDiagnostics.finishedAt.length > 0) {
+        lines.push(`Finished at: ${parseDiagnostics.finishedAt}`);
+      }
+      if (Number.isFinite(parseDiagnostics.totalDurationMs)) {
+        lines.push(`Total parse time: ${formatRocqSyncDuration(parseDiagnostics.totalDurationMs)}`);
+      }
+      if (parseDiagnostics.summary) {
+        lines.push(`Summary: ${formatBspParseSummary(parseDiagnostics.summary)}`);
+      }
+      if (parseDiagnostics.lastEvent) {
+        lines.push(`Last parse event: ${parseDiagnostics.lastEvent.stage}`);
+        lines.push(`Last parse payload: ${summarizeRocqSyncPayload(parseDiagnostics.lastEvent.payload, 240)}`);
+      } else {
+        lines.push('Last parse event: (none)');
+      }
+      if (parseDiagnostics.events.length > 0) {
+        lines.push('', 'Recent parse events:');
+        for (const event of parseDiagnostics.events) {
+          lines.push(
+            `- ${firstNonEmptyText(event.at, '(unknown time)')} ${event.stage}: ` +
+            `${summarizeRocqSyncPayload(event.payload, 180)}`
+          );
+        }
+      }
+      return lines;
+    }
+
     function formatErrorReportForClipboard(report = window.orlyErrorReport) {
       if (!report) return '';
       const raw = firstNonEmptyText(report.raw);
@@ -1174,6 +1395,7 @@
         `User agent: ${navigator.userAgent}`,
         ...formatBuildMetadata(report.build),
         `Location: ${formatErrorLocation(report.location)}`,
+        ...formatBspParseDiagnosticsForClipboard(report.parseDiagnostics),
         ...formatRocqSyncDiagnosticsForClipboard(report.diagnostics),
         '',
         'Stack trace:',
@@ -1232,8 +1454,13 @@
       status,
       error,
       fallback = 'Unknown error',
+      parseDiagnostics = null,
       diagnostics = null,
     }) {
+      const bspParseDiagnostics =
+        cloneBspParseDiagnostics(parseDiagnostics) ??
+        cloneBspParseDiagnostics(error?.parseDiagnostics) ??
+        cloneBspParseDiagnostics();
       const rocqSyncDiagnostics =
         cloneRocqSyncDiagnostics(diagnostics) ??
         cloneRocqSyncDiagnostics(error?.diagnostics) ??
@@ -1246,6 +1473,9 @@
         build: currentBuildInfo(),
         ...normalizeErrorReport(error, fallback),
       };
+      if (hasMeaningfulBspParseDiagnostics(bspParseDiagnostics)) {
+        report.parseDiagnostics = bspParseDiagnostics;
+      }
       if (rocqSyncDiagnostics) {
         report.diagnostics = rocqSyncDiagnostics;
       }
@@ -1290,6 +1520,7 @@
     }
 
     window.orlyBuildInfo = await loadBuildInfo();
+    resetBspParseDiagnostics();
     resetRocqSyncDiagnostics();
     clearErrorReport();
     copyErrorButton.addEventListener('click', () => {
@@ -1602,8 +1833,16 @@
           `Parsing ${selectedMapLabel} BSP…`,
           'Decoding level geometry and lightmaps.'
         );
-        const bsp = parseBsp(bspBuffer);
-        console.log(`orly: parsed BSP — ${bsp.faces.length} faces, ` +
+        beginBspParseDiagnostics(selectedMapLabel, bspBuffer);
+        const bsp = parseBsp(bspBuffer, {
+          onDiagnostic: recordBspParseDiagnostic,
+        });
+        finishBspParseDiagnostics('ready', bsp);
+        const parseDurationMs = cloneBspParseDiagnostics()?.totalDurationMs;
+        const parseDurationText = Number.isFinite(parseDurationMs)
+          ? ` in ${formatRocqSyncDuration(parseDurationMs)}`
+          : '';
+        console.log(`orly: parsed BSP${parseDurationText} — ${bsp.faces.length} faces, ` +
                     `${bsp.vertices.length} vertices, ` +
                     `${bsp.lightmaps.length} lightmaps`);
 
@@ -1741,6 +1980,9 @@
         clearStatus();
         console.log('orly: render pipeline active — snapshot seeded from Rocq state');
       } catch (err) {
+        if (cloneBspParseDiagnostics()?.state === 'parsing') {
+          finishBspParseDiagnostics('failed');
+        }
         console.error('BSP render init failed:', err);
         const msg = errorDetail(err);
         const isRocqSyncTimeout = err?.name === 'RocqSyncTimeoutError';
@@ -1749,6 +1991,7 @@
           title: isRocqSyncTimeout ? 'Rocq render sync timed out' : 'Render startup failed',
           status: isRocqSyncTimeout ? `Rocq sync timeout: ${msg}` : `Render error: ${msg}`,
           error: err,
+          parseDiagnostics: cloneBspParseDiagnostics(),
           diagnostics: cloneRocqSyncDiagnostics(),
         });
       }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1740,7 +1740,8 @@
         onDiagnostic: recordRocqSyncDiagnostic,
       });
       // Start compiling the bridge helpers immediately so theory loading
-      // overlaps asset fetch instead of blocking the first render sync.
+      // overlaps asset fetch. load_world waits on the same promise under
+      // the Rocq sync timeout, so users do not get stuck on the BSP parse UI.
       rocqBridgeWarmup =
         typeof rocqBridge.prepare === 'function'
           ? rocqBridge.prepare()
@@ -1846,18 +1847,14 @@
                     `${bsp.vertices.length} vertices, ` +
                     `${bsp.lightmaps.length} lightmaps`);
 
-        if (!rocqBridge) {
-          throw new Error('Rocq bridge is unavailable');
-        }
-        if (rocqBridgeWarmup) {
-          await rocqBridgeWarmup;
-        }
-
         showStatus('Syncing Rocq render state…');
         showPlaceholder(
           'Syncing Rocq render state…',
           'Building the initial render snapshot from the verified game core.'
         );
+        if (!rocqBridge) {
+          throw new Error('Rocq bridge is unavailable');
+        }
         const rocqSyncWorld = {
           entities: bsp.entities,
           faces: bsp.faces,

--- a/docs/rocq_bridge.js
+++ b/docs/rocq_bridge.js
@@ -273,9 +273,14 @@ async function waitForSentenceSid(sentence) {
   return sentence.coq_sid;
 }
 
-async function ensureBridgeHelpersReady(manager) {
-  await manager.when_ready.promise;
+async function waitForSentenceProcessed(manager, sid) {
+  while (!manager.coq.sids?.[sid]?.promise) {
+    await nextTick();
+  }
+  await manager.coq.sids[sid].promise;
+}
 
+async function ensureBridgeHelpersReady(manager) {
   let sentence = manager.doc.sentences.find(stm =>
     stm.coq_sid && stm.text.includes(BRIDGE_HELPERS_DEFINITION));
   if (sentence) return sentence.coq_sid;
@@ -283,7 +288,7 @@ async function ensureBridgeHelpersReady(manager) {
   while (manager.goNext(false)) {
     sentence = manager.doc.sentences[manager.doc.sentences.length - 1];
     const sid = await waitForSentenceSid(sentence);
-    await manager.coq.sids[sid].promise;
+    await waitForSentenceProcessed(manager, sid);
     if (sentence.text.includes(BRIDGE_HELPERS_DEFINITION)) {
       return sid;
     }

--- a/scripts/repro-q3dm1-render.mjs
+++ b/scripts/repro-q3dm1-render.mjs
@@ -231,13 +231,18 @@ async function createScenarioRoot(scenarioName) {
   await fs.cp(DOCS_DIR, rootDir, { recursive: true });
   await fs.rm(path.join(rootDir, 'assets'), { recursive: true, force: true });
 
-  if (scenarioName === 'licensed-map-render-startup' || scenarioName === 'rocq-sync-timeout-overlay') {
+  if (scenarioName === 'licensed-map-render-startup' ||
+      scenarioName === 'licensed-map-parse-handoff' ||
+      scenarioName === 'rocq-sync-timeout-overlay') {
     await fs.mkdir(path.join(rootDir, 'assets', 'maps'), { recursive: true });
     await fs.writeFile(
       path.join(rootDir, 'assets', 'manifest.json'),
       `${JSON.stringify([LICENSED_MAP_PATH])}\n`
     );
     await fs.copyFile(LICENSED_MAP_SOURCE, path.join(rootDir, 'assets', LICENSED_MAP_PATH));
+  }
+
+  if (scenarioName === 'licensed-map-render-startup' || scenarioName === 'rocq-sync-timeout-overlay') {
     await fs.writeFile(
       path.join(rootDir, 'rocq_bridge.js'),
       scenarioName === 'rocq-sync-timeout-overlay' ? HANGING_BRIDGE_SOURCE : STUB_BRIDGE_SOURCE
@@ -556,6 +561,42 @@ function detectStalledRocqSync(snapshot) {
   );
 }
 
+function summarizeBspParseState(snapshot) {
+  const diagnostics = snapshot?.bspParseDiagnostics ?? null;
+  if (!diagnostics) return 'parseDiagnostics=(missing)';
+
+  const parts = [
+    `state="${diagnostics.state ?? '(missing)'}"`,
+    `map="${diagnostics.mapLabel ?? '(missing)'}"`,
+  ];
+  if (Number.isFinite(diagnostics.totalDurationMs)) {
+    parts.push(`durationMs=${Math.round(diagnostics.totalDurationMs)}`);
+  }
+  if (diagnostics.lastEvent?.stage) {
+    parts.push(`lastEvent="${diagnostics.lastEvent.stage}"`);
+  }
+  return parts.join(', ');
+}
+
+function detectStalledBspParse(snapshot) {
+  const statusText = snapshot?.status?.text ?? '';
+  const placeholder = snapshot?.placeholder ?? null;
+  const placeholderTitle = String(placeholder?.title ?? '').trim();
+  if (statusText !== 'Parsing BSP…') {
+    return null;
+  }
+  if (snapshot?.status?.hidden !== false) {
+    return null;
+  }
+  if (placeholder?.hidden !== false || placeholder.state !== 'loading') {
+    return null;
+  }
+  if (!placeholderTitle.startsWith('Parsing ') || !placeholderTitle.endsWith(' BSP…')) {
+    return null;
+  }
+  return `bsp-parse-stalled: ${summarizeBspParseState(snapshot)}`;
+}
+
 async function waitForScenario(page, consoleEvents, predicate, timeoutFailure = null, stopOnFailure = true) {
   const deadline = Date.now() + TIMEOUT_MS;
   let snapshot = await gatherSnapshotWithRetry(page);
@@ -678,6 +719,63 @@ function assertDesktopRenderStartupScenario(snapshot, consoleEvents) {
   }
   if (!snapshot.hints?.desktop?.visible) {
     throw new Error('desktop hint should stay visible in desktop render scenario');
+  }
+}
+
+function assertRealBridgeParseHandoffScenario(snapshot, consoleEvents) {
+  const failure = detectFailure(snapshot, consoleEvents);
+  if (failure) {
+    throw new Error(failure);
+  }
+  if (!snapshot.jscoqLoaded) {
+    throw new Error('JsCoq editor did not load');
+  }
+  if (snapshot.assetCount !== 1) {
+    throw new Error(`expected one licensed map asset, got ${snapshot.assetCount}`);
+  }
+
+  const diagnostics = snapshot.bspParseDiagnostics;
+  if (!diagnostics) {
+    throw new Error('BSP parse diagnostics were not captured');
+  }
+  if (diagnostics.state !== 'ready') {
+    throw new Error(`expected BSP parse diagnostics to be ready, got ${diagnostics.state ?? '(missing)'}`);
+  }
+  if (!Number.isFinite(diagnostics.totalDurationMs) || diagnostics.totalDurationMs <= 0) {
+    throw new Error(`unexpected BSP parse duration: ${diagnostics.totalDurationMs ?? '(missing)'}`);
+  }
+  if ((diagnostics.summary?.faceCount ?? 0) <= 0) {
+    throw new Error(`unexpected BSP face count: ${diagnostics.summary?.faceCount ?? '(missing)'}`);
+  }
+  if ((diagnostics.summary?.lightmapCount ?? 0) <= 0) {
+    throw new Error(`unexpected BSP lightmap count: ${diagnostics.summary?.lightmapCount ?? '(missing)'}`);
+  }
+  if (diagnostics.lastEvent?.stage !== 'parse:complete') {
+    throw new Error(`unexpected BSP parse last event: ${diagnostics.lastEvent?.stage ?? '(missing)'}`);
+  }
+
+  if (snapshot.status?.hidden !== false) {
+    throw new Error('status bar hid before Rocq sync started');
+  }
+  if (snapshot.status?.text !== 'Syncing Rocq render state…') {
+    throw new Error(`expected Rocq sync status after BSP parse, got ${snapshot.status?.text ?? '(empty)'}`);
+  }
+  if (snapshot.status?.className !== 'loading') {
+    throw new Error(`expected loading status during Rocq handoff, got ${snapshot.status?.className ?? '(missing)'}`);
+  }
+
+  if (snapshot.placeholder?.hidden !== false || snapshot.placeholder?.state !== 'loading') {
+    throw new Error('placeholder should stay visible while Rocq sync is loading');
+  }
+  if (snapshot.placeholder?.title !== 'Syncing Rocq render state…') {
+    throw new Error(`unexpected placeholder title after parse handoff: ${snapshot.placeholder?.title ?? '(missing)'}`);
+  }
+  if (!snapshot.placeholder?.detail.includes('verified game core')) {
+    throw new Error(`unexpected placeholder detail after parse handoff: ${snapshot.placeholder?.detail ?? '(missing)'}`);
+  }
+
+  if (!hasEvent(consoleEvents, /orly: parsed BSP/i)) {
+    throw new Error('console never reported a parsed BSP before the Rocq handoff');
   }
 }
 
@@ -1289,6 +1387,21 @@ async function main() {
           },
         },
         {
+          name: 'licensed-map-parse-handoff-real-bridge',
+          rootScenario: 'licensed-map-parse-handoff',
+          contextOptions: {
+            viewport: { width: 1280, height: 720 },
+          },
+          readyWhen(current) {
+            return current.bspParseDiagnostics?.state === 'ready'
+              && current.status?.text === 'Syncing Rocq render state…'
+              && current.placeholder?.title === 'Syncing Rocq render state…';
+          },
+          assert(snapshot, consoleEvents, interactions) {
+            assertRealBridgeParseHandoffScenario(interactions.readySnapshot, consoleEvents);
+          },
+        },
+        {
           name: 'licensed-map-render-startup-mobile-portrait',
           rootScenario: 'licensed-map-render-startup',
           contextOptions: IPHONE_13,
@@ -1365,7 +1478,7 @@ async function main() {
           };
         },
         timeoutFailure(snapshot) {
-          return detectStalledRocqSync(snapshot);
+          return detectStalledBspParse(snapshot) ?? detectStalledRocqSync(snapshot);
         },
         assert(snapshot, consoleEvents, interactions) {
           assertDeployedPagesScenario(snapshot, consoleEvents, interactions);

--- a/scripts/repro-q3dm1-render.mjs
+++ b/scripts/repro-q3dm1-render.mjs
@@ -285,6 +285,10 @@ async function gatherSnapshot(page) {
       window.orlyRocqSyncDiagnostics && typeof window.orlyRocqSyncDiagnostics === 'object'
         ? structuredClone(window.orlyRocqSyncDiagnostics)
         : null;
+    const bspParseDiagnostics =
+      window.orlyBspParseDiagnostics && typeof window.orlyBspParseDiagnostics === 'object'
+        ? structuredClone(window.orlyBspParseDiagnostics)
+        : null;
 
     function rectOf(element) {
       if (!element) return null;
@@ -441,6 +445,7 @@ async function gatherSnapshot(page) {
       },
       buildInfo,
       errorReport,
+      bspParseDiagnostics,
       rocqSyncDiagnostics,
       assetCount: assetMap?.size ?? null,
       jscoqLoaded: Boolean(document.querySelector('.CodeMirror')),


### PR DESCRIPTION
Fixes #67.

With BSP parse timing diagnostics in place, this PR now focuses on fixing the deployed GitHub Pages parse stall that leaves the demo stuck before Rocq sync begins. It also tightens the Pages smoke coverage so future parse regressions get caught fast.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Fix deployed BSP parse stall <!-- type:spec -->
- [x] Harden Pages smoke for parse regressions <!-- type:spec -->
- [x] Record BSP parse timing diagnostics <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->