### PR TITLE
Deployed demo still hits 'Rocq render sync timeout' after #64/#67 fixes shipped (closes #70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,18 +90,22 @@ npm run playwright:install
 npm run test:q3dm1-browser
 ```
 
-The regression script runs five scenarios against the local browser build:
+The regression script runs one bridge regression plus five scenarios against the
+local browser build:
 
-1. the assetless page load path, to ensure the JsCoq worker bootstrap still
+1. a direct bridge regression for the missing JsCoq sentence-promise race, to
+   ensure `load_world` can finish once the helper sentence reaches `processed`
+   even if no `coq.sids[sid].promise` is present
+2. the assetless page load path, to ensure the JsCoq worker bootstrap still
    succeeds without tripping over browser security restrictions
-2. a desktop startup path using a fetched/cached `maps/am_lavaarena.bsp`
+3. a desktop startup path using a fetched/cached `maps/am_lavaarena.bsp`
    licensed-map asset, to ensure the Rocq-seeded render pipeline reaches its
    first frame and hides the placeholder
-3. a real-bridge parse handoff path using the licensed BSP, to ensure the page
+4. a real-bridge parse handoff path using the licensed BSP, to ensure the page
    leaves the BSP parsing overlay and enters Rocq sync once decode completes
-4. an iPhone-sized portrait startup path, to ensure the mobile controls stay
+5. an iPhone-sized portrait startup path, to ensure the mobile controls stay
    visible, large enough to use, and safely inside the viewport
-5. an iPhone-sized landscape startup path, to ensure the split layout, control
+6. an iPhone-sized landscape startup path, to ensure the split layout, control
    reachability, and touch resize handle remain usable after rotation
 
 It writes screenshots plus JSON diagnostics under your system temp directory.

--- a/docs/rocq_bridge.js
+++ b/docs/rocq_bridge.js
@@ -8,6 +8,9 @@ const MIN_GAME_STATE_WORDS_COUNT = 19;
 const GEOMETRY_Q_SCALE = 1000000;
 const CONTENTS_SOLID = 1;
 const CONTENTS_PLAYERCLIP = 65536;
+const SENTENCE_PHASE_PROCESSED = 'processed';
+const SENTENCE_PHASE_ERROR = 'error';
+const SENTENCE_PHASE_CANCELLING = 'cancelling';
 
 function nextTick() {
   return new Promise(resolve => setTimeout(resolve, 0));
@@ -273,22 +276,41 @@ async function waitForSentenceSid(sentence) {
   return sentence.coq_sid;
 }
 
-async function waitForSentenceProcessed(manager, sid) {
-  while (!manager.coq.sids?.[sid]?.promise) {
+async function waitForManagerReady(manager) {
+  if (manager?.when_ready?.promise) {
+    await manager.when_ready.promise;
+    return;
+  }
+  while (!manager?.coq) {
     await nextTick();
   }
-  await manager.coq.sids[sid].promise;
+}
+
+async function waitForSentenceProcessed(sentence, sid) {
+  while (true) {
+    const phase = typeof sentence?.phase === 'string' ? sentence.phase : '';
+    if (phase === SENTENCE_PHASE_PROCESSED) return;
+    if (phase === SENTENCE_PHASE_ERROR || phase === SENTENCE_PHASE_CANCELLING) {
+      throw new Error(`Rocq sentence ${sid} stopped before it finished processing (phase: ${phase})`);
+    }
+    await nextTick();
+  }
 }
 
 async function ensureBridgeHelpersReady(manager) {
+  await waitForManagerReady(manager);
+
   let sentence = manager.doc.sentences.find(stm =>
     stm.coq_sid && stm.text.includes(BRIDGE_HELPERS_DEFINITION));
-  if (sentence) return sentence.coq_sid;
+  if (sentence) {
+    await waitForSentenceProcessed(sentence, sentence.coq_sid);
+    return sentence.coq_sid;
+  }
 
   while (manager.goNext(false)) {
     sentence = manager.doc.sentences[manager.doc.sentences.length - 1];
     const sid = await waitForSentenceSid(sentence);
-    await waitForSentenceProcessed(manager, sid);
+    await waitForSentenceProcessed(sentence, sid);
     if (sentence.text.includes(BRIDGE_HELPERS_DEFINITION)) {
       return sid;
     }

--- a/scripts/repro-q3dm1-render.mjs
+++ b/scripts/repro-q3dm1-render.mjs
@@ -780,8 +780,6 @@ function assertRealBridgeParseHandoffScenario(snapshot, consoleEvents) {
 }
 
 function assertDeployedPagesScenario(snapshot, consoleEvents, interactions) {
-  assertDesktopRenderStartupScenario(snapshot, consoleEvents);
-
   const assetChecks = interactions.deployedAssetChecks;
   if (!assetChecks) {
     throw new Error('deployed asset diagnostics missing');
@@ -817,6 +815,30 @@ function assertDeployedPagesScenario(snapshot, consoleEvents, interactions) {
       `deployed BSP conditional HEAD should return 304, got ${assetChecks.revalidateHead?.status ?? 'unknown'}`
     );
   }
+
+  const failure = detectFailure(snapshot, consoleEvents);
+  if (!failure) {
+    assertDesktopRenderStartupScenario(snapshot, consoleEvents);
+    return;
+  }
+
+  const copy = interactions.copyOverlay;
+  if (!copy) {
+    throw new Error(`${failure}\ndeployed error overlay was not captured`);
+  }
+
+  const capturedText = copy.fallbackText || copy.clipboardText || '';
+  if (capturedText.length === 0) {
+    throw new Error(`${failure}\ndeployed error overlay copy payload was empty`);
+  }
+  if (!capturedText.includes('Page URL: https://rhencke.github.io/orly/')) {
+    throw new Error(`${failure}\ndeployed error overlay copy payload was missing the page URL`);
+  }
+  if (!capturedText.includes('Source: ')) {
+    throw new Error(`${failure}\ndeployed error overlay copy payload was missing the error source`);
+  }
+
+  throw new Error(`${failure}\nCaptured deployed error report:\n${capturedText}`);
 }
 
 function assertRectWithinViewport(name, rect, viewport) {
@@ -1212,6 +1234,14 @@ async function copyCurrentErrorOverlay(page) {
   };
 }
 
+async function copyCurrentErrorOverlayIfVisible(page) {
+  const copyButton = page.locator('#copy-error-report');
+  if (!await copyButton.isVisible().catch(() => false)) {
+    return null;
+  }
+  return copyCurrentErrorOverlay(page);
+}
+
 async function exerciseErrorOverlayCopy(page) {
   await page.evaluate(() => {
     const error = new Error('Copy smoke error');
@@ -1264,6 +1294,7 @@ async function runScenario(browser, scenario, outDir, port) {
   const consoleEvents = [];
   let context = null;
   let page = null;
+  let interactions = null;
 
   try {
     await waitForUrl(url, scenario.url ? 30000 : 10000).catch(error => {
@@ -1296,13 +1327,12 @@ async function runScenario(browser, scenario, outDir, port) {
       scenario.stopOnFailure ?? true
     );
 
-    const extraInteractions = scenario.afterReady
-      ? await scenario.afterReady(page)
-      : null;
-    const interactions = {
+    interactions = {
       readySnapshot: snapshot,
-      ...(extraInteractions ?? {}),
     };
+    if (scenario.afterReady) {
+      Object.assign(interactions, await scenario.afterReady(page, snapshot, consoleEvents));
+    }
     const finalSnapshot = await gatherSnapshotWithRetry(page);
 
     const screenshotPath = path.join(outDir, `${scenario.name}.png`);
@@ -1332,6 +1362,7 @@ async function runScenario(browser, scenario, outDir, port) {
       url,
       failure: error.message,
       snapshot: failureSnapshot,
+      interactions,
       consoleEvents,
       serverLogs: serverInfo?.readLogs() ?? null,
       screenshotPath,
@@ -1472,9 +1503,16 @@ async function main() {
         contextOptions: {
           viewport: { width: 1280, height: 720 },
         },
-        async afterReady() {
+        permissions: ['clipboard-read', 'clipboard-write'],
+        async afterReady(page, snapshot, consoleEvents) {
+          const shouldCaptureErrorOverlay = Boolean(detectFailure(snapshot, consoleEvents));
+          const [deployedAssetChecks, copyOverlay] = await Promise.all([
+            inspectDeployedAssetCaching(DEPLOYED_URL),
+            shouldCaptureErrorOverlay ? copyCurrentErrorOverlayIfVisible(page) : Promise.resolve(null),
+          ]);
           return {
-            deployedAssetChecks: await inspectDeployedAssetCaching(DEPLOYED_URL),
+            deployedAssetChecks,
+            copyOverlay,
           };
         },
         timeoutFailure(snapshot) {

--- a/scripts/repro-q3dm1-render.mjs
+++ b/scripts/repro-q3dm1-render.mjs
@@ -139,8 +139,144 @@ export function createRocqBridge(_manager, options = {}) {
 }
 `;
 
+async function withNodeTimeout(promise, timeoutMs, message) {
+  let timeoutId = null;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error(message)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId !== null) clearTimeout(timeoutId);
+  }
+}
+
 async function sleep(ms) {
   await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function runMissingSentencePromiseRegression() {
+  const scenario = 'bridge-missing-sentence-promise-regression';
+
+  try {
+    const { createRocqBridge } =
+      await import(new URL('../docs/rocq_bridge.js', import.meta.url));
+    const diagnostics = [];
+    const queryCalls = [];
+    const helperSentence = {
+      text: 'Definition step_world_words_in_world := step_world_words_in_world.',
+      coq_sid: 7,
+      phase: 'processing',
+    };
+    const manager = {
+      when_ready: {
+        promise: Promise.resolve(),
+      },
+      doc: {
+        sentences: [helperSentence],
+      },
+      goNext() {
+        return false;
+      },
+      pprint: {
+        pp2Text(message) {
+          return message;
+        },
+      },
+      coq: {
+        // The regression is that helper readiness must not depend on
+        // coq.sids[sid].promise existing on the manager.
+        queryPromise(sid, query) {
+          const command = Array.isArray(query) ? String(query[1] ?? '') : String(query ?? '');
+          queryCalls.push({ sid, command });
+
+          if (command.includes('initial_game_state_words_from_entities')) {
+            return Promise.resolve([
+              { msg: '= [0; 1; 0; 1; 0; 1; 0; 1; 0; 1; 0; 1; 0; 1; 0; 1; 1; 0; 0]' },
+            ]);
+          }
+          if (command.includes('initial_visible_faces_from_inputs')) {
+            return Promise.resolve([{ msg: '= []' }]);
+          }
+
+          throw new Error(`unexpected Rocq query in regression: ${command}`);
+        },
+      },
+    };
+    const bridge = createRocqBridge(manager, {
+      onDiagnostic(event) {
+        diagnostics.push(event);
+      },
+    });
+    const world = {
+      entities: [],
+      faces: [],
+      textures: [],
+      planes: [],
+      models: [],
+      brushes: [],
+      brushSides: [],
+    };
+
+    const preparePromise = bridge.prepare();
+    const loadWorldPromise = bridge.load_world(world);
+
+    setTimeout(() => {
+      helperSentence.phase = 'processed';
+    }, 25);
+
+    const snapshot = await withNodeTimeout(
+      loadWorldPromise,
+      1000,
+      'timed out waiting for load_world after load_world:requested without a JsCoq sentence promise'
+    );
+    await withNodeTimeout(
+      preparePromise,
+      1000,
+      'timed out waiting for prepare without a JsCoq sentence promise'
+    );
+
+    const stages = diagnostics.map(event => event.stage);
+    if (stages[0] !== 'load_world:requested') {
+      throw new Error(`unexpected first regression stage: ${stages[0] ?? '(missing)'}`);
+    }
+    if (!stages.includes('load_world:helpers-ready')) {
+      throw new Error('helper readiness regression never reached load_world:helpers-ready');
+    }
+    if (!stages.includes('load_world:complete')) {
+      throw new Error('helper readiness regression never reached load_world:complete');
+    }
+    if (queryCalls.length !== 2) {
+      throw new Error(`expected two Rocq queries in regression, got ${queryCalls.length}`);
+    }
+    if (!Array.isArray(snapshot.visibleFaces)) {
+      throw new Error('regression snapshot did not include visibleFaces');
+    }
+
+    return {
+      scenario,
+      passed: true,
+      details: {
+        diagnostics,
+        queryCalls,
+        snapshot: {
+          position: snapshot.position,
+          yaw: snapshot.yaw,
+          pitch: snapshot.pitch,
+          visibleFaceCount: snapshot.visibleFaces.length,
+        },
+      },
+    };
+  } catch (error) {
+    return {
+      scenario,
+      passed: false,
+      failure: error.message,
+      stack: error.stack ?? '',
+    };
+  }
 }
 
 async function waitForUrl(url, timeoutMs) {
@@ -1396,6 +1532,10 @@ async function main() {
     const outDir = await fs.mkdtemp(path.join(os.tmpdir(), 'orly-licensed-map-regression-'));
     const diagnosticsPath = path.join(outDir, 'diagnostics.json');
     const scenarios = [];
+
+    if (!SKIP_LOCAL_SCENARIOS) {
+      scenarios.push(await runMissingSentencePromiseRegression());
+    }
 
     const scenarioConfigs = [];
 


### PR DESCRIPTION
This PR now narrows to the regression that reproduces the deployed Pages race behind the stalled `load_world:requested` handoff. It locks in the bridge-readiness fix by exercising the case where the expected JsCoq sentence promise is absent or delayed.

Fixes #70.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] Add regression for missing JsCoq sentence promises <!-- type:spec -->
- [x] [harden Rocq bridge helper readiness on Pages](https://github.com/rhencke/orly/pull/71#issuecomment-4272460301) <!-- type:thread -->
- [x] Capture deployed sync timeout reports in Pages smoke <!-- type:spec -->
- [x] Harden Rocq bridge helper readiness after load_world handoff <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->