### PR TITLE
Instrument the in-browser Rocq worker's load_world path so timeouts are diagnosable (closes #74)

### DIFF
--- a/docs/rocq_bridge.js
+++ b/docs/rocq_bridge.js
@@ -297,8 +297,9 @@ async function waitForSentenceProcessed(sentence, sid) {
   }
 }
 
-async function ensureBridgeHelpersReady(manager) {
+async function ensureBridgeHelpersReady(manager, onDiagnostic = null) {
   await waitForManagerReady(manager);
+  emitDiagnostic(onDiagnostic, 'rocq:alive', {});
 
   let sentence = manager.doc.sentences.find(stm =>
     stm.coq_sid && stm.text.includes(BRIDGE_HELPERS_DEFINITION));
@@ -363,7 +364,7 @@ export function createRocqBridge(manager, options = {}) {
     typeof options.onDiagnostic === 'function' ? options.onDiagnostic : null;
 
   function getBridgeHelpersSid() {
-    bridgeHelpersSidPromise ||= ensureBridgeHelpersReady(manager);
+    bridgeHelpersSidPromise ||= ensureBridgeHelpersReady(manager, onDiagnostic);
     return bridgeHelpersSidPromise;
   }
 

--- a/docs/rocq_bridge.js
+++ b/docs/rocq_bridge.js
@@ -380,26 +380,79 @@ export function createRocqBridge(manager, options = {}) {
     },
 
     async load_world(world) {
+      const loadStartedAtMs = Date.now();
       emitDiagnostic(onDiagnostic, 'load_world:requested', summarizeWorld(world));
-      const sid = await getBridgeHelpersSid();
+      let sid;
+      try {
+        sid = await getBridgeHelpersSid();
+      } catch (err) {
+        emitDiagnostic(onDiagnostic, 'load_world:failed', {
+          phase: 'helpers-ready',
+          error: err.message,
+          durationMs: Date.now() - loadStartedAtMs,
+        });
+        throw err;
+      }
       emitDiagnostic(onDiagnostic, 'load_world:helpers-ready', { sid });
-      const wordsPromise = evalInitialGameStateWords(manager, sid, world)
-        .then(words => {
-          emitDiagnostic(onDiagnostic, 'load_world:game-state-words', summarizeWordList(words));
+
+      const wordsPromise = (async () => {
+        emitDiagnostic(onDiagnostic, 'load_world:game-state-words:start', {});
+        const t0 = Date.now();
+        try {
+          const words = await evalInitialGameStateWords(manager, sid, world);
+          emitDiagnostic(onDiagnostic, 'load_world:game-state-words', {
+            ...summarizeWordList(words),
+            durationMs: Date.now() - t0,
+          });
           return words;
-        });
-      const facesPromise = evalVisibleFaces(manager, sid, world)
-        .then(faces => {
-          emitDiagnostic(onDiagnostic, 'load_world:visible-faces', summarizeWordList(faces));
+        } catch (err) {
+          emitDiagnostic(onDiagnostic, 'load_world:game-state-words:failed', {
+            error: err.message,
+            durationMs: Date.now() - t0,
+          });
+          throw err;
+        }
+      })();
+
+      const facesPromise = (async () => {
+        emitDiagnostic(onDiagnostic, 'load_world:visible-faces:start', {});
+        const t0 = Date.now();
+        try {
+          const faces = await evalVisibleFaces(manager, sid, world);
+          emitDiagnostic(onDiagnostic, 'load_world:visible-faces', {
+            ...summarizeWordList(faces),
+            durationMs: Date.now() - t0,
+          });
           return faces;
+        } catch (err) {
+          emitDiagnostic(onDiagnostic, 'load_world:visible-faces:failed', {
+            error: err.message,
+            durationMs: Date.now() - t0,
+          });
+          throw err;
+        }
+      })();
+
+      let words, faces;
+      try {
+        [words, faces] = await Promise.all([wordsPromise, facesPromise]);
+      } catch (err) {
+        emitDiagnostic(onDiagnostic, 'load_world:failed', {
+          error: err.message,
+          durationMs: Date.now() - loadStartedAtMs,
         });
-      const [words, faces] = await Promise.all([wordsPromise, facesPromise]);
+        throw err;
+      }
+
       collisionWorldExpr = formatCollisionWorld(world);
       gsWords        = words;
       initialGsWords = [...words];
       visibleFaces   = faces;
       const snapshot = snapshotFromGameStateWords(gsWords, visibleFaces);
-      emitDiagnostic(onDiagnostic, 'load_world:complete', summarizeSnapshot(snapshot));
+      emitDiagnostic(onDiagnostic, 'load_world:complete', {
+        ...summarizeSnapshot(snapshot),
+        durationMs: Date.now() - loadStartedAtMs,
+      });
       return snapshot;
     },
 

--- a/scripts/browser-test.mjs
+++ b/scripts/browser-test.mjs
@@ -1614,6 +1614,9 @@ async function exerciseKeyboardResize(page) {
   await page.keyboard.press('ArrowLeft');
   await page.waitForTimeout(100);
   const afterGrow = await gatherSnapshotWithRetry(page);
+  // Re-focus the handle: JsCoq's ResizeObserver can steal focus when the
+  // panel resizes, so we restore it explicitly before the restore keypress.
+  await handle.focus();
   await page.keyboard.press('ArrowRight');
   await page.waitForTimeout(100);
   const afterRestore = await gatherSnapshotWithRetry(page);

--- a/scripts/browser-test.mjs
+++ b/scripts/browser-test.mjs
@@ -71,7 +71,9 @@ export function createRocqBridge(_manager, options = {}) {
   return {
     version: 1,
 
-    async prepare() {},
+    async prepare() {
+      emit('rocq:alive', {});
+    },
 
     async load_world(world) {
       visibleFaces = Array.isArray(world?.faces)
@@ -114,7 +116,9 @@ export function createRocqBridge(_manager, options = {}) {
   return {
     version: 1,
 
-    async prepare() {},
+    async prepare() {
+      emit('rocq:alive', {});
+    },
 
     async load_world(world) {
       emit('load_world:requested', {
@@ -241,6 +245,9 @@ async function runMissingSentencePromiseRegression() {
     const stages = diagnostics.map(event => event.stage);
     if (stages[0] !== 'load_world:requested') {
       throw new Error(`unexpected first regression stage: ${stages[0] ?? '(missing)'}`);
+    }
+    if (!stages.includes('rocq:alive')) {
+      throw new Error('helper readiness regression never received rocq:alive heartbeat');
     }
     if (!stages.includes('load_world:helpers-ready')) {
       throw new Error('helper readiness regression never reached load_world:helpers-ready');


### PR DESCRIPTION
Fixes #74.

Instruments the Rocq worker's `load_world` path with phase-boundary diagnostics (`rocq:alive`, `load_world:received`, `load_world:decoded`, `load_world:snapshot_built`, `load_world:failed`) so timeout failures can be triaged into message-routing, decode-stall, or response-routing buckets. Also bumps the default sync timeout from 15s to 60s to give the new instrumentation room to capture where things actually stick.

---

## Work queue

<!-- WORK_QUEUE_START -->
- [ ] Add load_world phase-boundary diagnostics and error capture **→ next** <!-- type:spec -->
- [ ] Bump default Rocq sync timeout from 15s to 60s <!-- type:spec -->

<details><summary>Completed (1)</summary>

- [x] Emit rocq:alive heartbeat when JsCoq worker is ready <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->