### PR TITLE
Instrument the in-browser Rocq worker's load_world path so timeouts are diagnosable (closes #74)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1138,7 +1138,7 @@
 
     const COPY_BUTTON_LABEL = 'Copy';
     const COPY_BUTTON_COPIED_LABEL = 'Copied!';
-    const DEFAULT_ROCQ_SYNC_TIMEOUT_MS = 15000;
+    const DEFAULT_ROCQ_SYNC_TIMEOUT_MS = 60000;
     const MAX_BSP_PARSE_EVENT_HISTORY = 24;
     const MAX_ROCQ_SYNC_EVENT_HISTORY = 8;
     let copyFeedbackTimeoutId = null;

--- a/docs/rocq_bridge.js
+++ b/docs/rocq_bridge.js
@@ -369,6 +369,16 @@ export function createRocqBridge(manager, options = {}) {
   const onDiagnostic =
     typeof options.onDiagnostic === 'function' ? options.onDiagnostic : null;
 
+  // Emit rocq:alive as soon as the JsCoq manager becomes ready — before any
+  // load_world work starts.  A timeout that shows no rocq:alive event means
+  // the Rocq WASM worker never came up at all (case A in #74 where the
+  // message routing itself is suspect).
+  waitForManagerReady(manager).then(() => {
+    emitDiagnostic(onDiagnostic, 'rocq:alive', {});
+  }).catch(() => {
+    // waitForManagerReady resolves; catch is a safeguard only.
+  });
+
   function getBridgeHelpersSid() {
     bridgeHelpersSidPromise ||= ensureBridgeHelpersReady(manager);
     return bridgeHelpersSidPromise;

--- a/docs/rocq_bridge.js
+++ b/docs/rocq_bridge.js
@@ -260,6 +260,13 @@ function summarizeSnapshot(snapshot) {
   };
 }
 
+function summarizeError(err) {
+  return {
+    message: err instanceof Error ? err.message : String(err),
+    stack: err instanceof Error ? (err.stack || '') : '',
+  };
+}
+
 function emitDiagnostic(emit, stage, payload = {}) {
   if (!emit) return;
   emit({
@@ -379,27 +386,48 @@ export function createRocqBridge(manager, options = {}) {
     },
 
     async load_world(world) {
-      emitDiagnostic(onDiagnostic, 'load_world:requested', summarizeWorld(world));
-      const sid = await getBridgeHelpersSid();
-      emitDiagnostic(onDiagnostic, 'load_world:helpers-ready', { sid });
-      const wordsPromise = evalInitialGameStateWords(manager, sid, world)
-        .then(words => {
-          emitDiagnostic(onDiagnostic, 'load_world:game-state-words', summarizeWordList(words));
-          return words;
+      try {
+        emitDiagnostic(onDiagnostic, 'load_world:requested', summarizeWorld(world));
+        const sid = await getBridgeHelpersSid();
+        emitDiagnostic(onDiagnostic, 'load_world:helpers-ready', { sid });
+        // Fires right before queryPromise calls — confirms Rocq worker is being
+        // invoked.  A timeout gap between helpers-ready and received means the
+        // manager handoff stalled; a gap after received means the WASM worker
+        // itself stalled (case B in #74).
+        emitDiagnostic(onDiagnostic, 'load_world:received', { sid });
+        const wordsPromise = evalInitialGameStateWords(manager, sid, world)
+          .then(words => {
+            emitDiagnostic(onDiagnostic, 'load_world:game-state-words', summarizeWordList(words));
+            return words;
+          });
+        const facesPromise = evalVisibleFaces(manager, sid, world)
+          .then(faces => {
+            emitDiagnostic(onDiagnostic, 'load_world:visible-faces', summarizeWordList(faces));
+            return faces;
+          });
+        const [words, faces] = await Promise.all([wordsPromise, facesPromise]);
+        // Both Rocq queries resolved and their outputs are parsed — all Rocq
+        // data is in hand.  A gap here (after visible-faces/game-state-words
+        // but before decoded) would indicate one query stalled.
+        emitDiagnostic(onDiagnostic, 'load_world:decoded', {
+          gsWordCount: words.length,
+          visibleFaceCount: faces.length,
         });
-      const facesPromise = evalVisibleFaces(manager, sid, world)
-        .then(faces => {
-          emitDiagnostic(onDiagnostic, 'load_world:visible-faces', summarizeWordList(faces));
-          return faces;
-        });
-      const [words, faces] = await Promise.all([wordsPromise, facesPromise]);
-      collisionWorldExpr = formatCollisionWorld(world);
-      gsWords        = words;
-      initialGsWords = [...words];
-      visibleFaces   = faces;
-      const snapshot = snapshotFromGameStateWords(gsWords, visibleFaces);
-      emitDiagnostic(onDiagnostic, 'load_world:complete', summarizeSnapshot(snapshot));
-      return snapshot;
+        collisionWorldExpr = formatCollisionWorld(world);
+        gsWords        = words;
+        initialGsWords = [...words];
+        visibleFaces   = faces;
+        const snapshot = snapshotFromGameStateWords(gsWords, visibleFaces);
+        // Snapshot object is fully constructed on the JS side.  A gap between
+        // snapshot_built and complete would indicate the return path stalled
+        // (case C in #74).
+        emitDiagnostic(onDiagnostic, 'load_world:snapshot_built', summarizeSnapshot(snapshot));
+        emitDiagnostic(onDiagnostic, 'load_world:complete', summarizeSnapshot(snapshot));
+        return snapshot;
+      } catch (err) {
+        emitDiagnostic(onDiagnostic, 'load_world:failed', summarizeError(err));
+        throw err;
+      }
     },
 
     async step(inputSnapshot) {

--- a/scripts/browser-test.mjs
+++ b/scripts/browser-test.mjs
@@ -80,7 +80,15 @@ export function createRocqBridge(_manager, options = {}) {
       emit('load_world:requested', {
         faceCount: visibleFaces.length,
       });
+      emit('load_world:received', {});
       const nextSnapshot = snapshot();
+      emit('load_world:decoded', {
+        gsWordCount: 0,
+        visibleFaceCount: nextSnapshot.visibleFaces.length,
+      });
+      emit('load_world:snapshot_built', {
+        visibleFaceCount: nextSnapshot.visibleFaces.length,
+      });
       emit('load_world:complete', {
         visibleFaceCount: nextSnapshot.visibleFaces.length,
       });
@@ -242,8 +250,20 @@ async function runMissingSentencePromiseRegression() {
     if (stages[0] !== 'load_world:requested') {
       throw new Error(`unexpected first regression stage: ${stages[0] ?? '(missing)'}`);
     }
+    if (!stages.includes('rocq:alive')) {
+      throw new Error('helper readiness regression never received rocq:alive heartbeat');
+    }
     if (!stages.includes('load_world:helpers-ready')) {
       throw new Error('helper readiness regression never reached load_world:helpers-ready');
+    }
+    if (!stages.includes('load_world:received')) {
+      throw new Error('helper readiness regression never reached load_world:received');
+    }
+    if (!stages.includes('load_world:decoded')) {
+      throw new Error('helper readiness regression never reached load_world:decoded');
+    }
+    if (!stages.includes('load_world:snapshot_built')) {
+      throw new Error('helper readiness regression never reached load_world:snapshot_built');
     }
     if (!stages.includes('load_world:complete')) {
       throw new Error('helper readiness regression never reached load_world:complete');


### PR DESCRIPTION
Fixes #74.

Instruments the Rocq bridge's `load_world` path with phase-boundary diagnostic events (`received`, `decoded`, `snapshot_built`, `failed`) and a `rocq:alive` heartbeat so timeout failures can be triaged to their root cause. Also bumps the default sync timeout from 15s to 60s to capture longer stalls during diagnosis, with updated browser tests covering the new events and timeout value.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] Bump default Rocq sync timeout from 15s to 60s for diagnosis <!-- type:spec -->
- [x] Update browser tests for new instrumentation events and timeout <!-- type:spec -->
- [x] Emit rocq:alive heartbeat when the Rocq worker initializes <!-- type:spec -->
- [x] Add load_world phase-boundary diagnostics (received, decoded, snapshot_built, failed) <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->