### PR TITLE
Deployed demo still hits 'Rocq render sync timeout' after #64/#67 fixes shipped (closes #70)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1493,6 +1493,10 @@
         ...diagnostics.events.slice(-(MAX_ROCQ_SYNC_EVENT_HISTORY - 1)),
         normalized,
       ];
+      // Signal to withActivityTimeout that Rocq is alive and making progress.
+      // This resets the inactivity countdown so slow-but-progressing compilation
+      // (e.g. stepping through 2000+ lines of theory) is never killed mid-flight.
+      rocqSyncActivityReset?.();
     }
 
     function finishRocqSyncDiagnostics(state) {
@@ -1583,6 +1587,47 @@
         ]);
       } finally {
         if (timeoutId !== null) window.clearTimeout(timeoutId);
+      }
+    }
+
+    // Like withTimeout, but the inactivity deadline resets every time activity
+    // occurs.  'registerReset' is called once with a reset function; the caller
+    // stores it somewhere and invokes it whenever "activity" should reset the
+    // timer (e.g. a bridge diagnostic event arriving).  When the promise settles
+    // (or the timeout fires), registerReset is called with null to unregister.
+    //
+    // The timeout only fires if no activity occurs for timeoutMs milliseconds.
+    // A slow-but-progressing Rocq compilation that emits compile:sentence events
+    // every few seconds will never trip this timer.
+    async function withActivityTimeout(promise, timeoutMs, registerReset, createError) {
+      let timeoutId = null;
+      let rejectFn = null;
+
+      function reset() {
+        // Guard: promise may have already settled (rejectFn cleared in finally).
+        if (rejectFn === null) return;
+        if (timeoutId !== null) window.clearTimeout(timeoutId);
+        timeoutId = window.setTimeout(() => {
+          // Double-check inside the callback — another reset may have fired
+          // synchronously between the tick and here.
+          if (rejectFn !== null) rejectFn(createError());
+        }, timeoutMs);
+      }
+
+      try {
+        const timeoutPromise = new Promise((_, reject) => {
+          rejectFn = reject;
+          registerReset(reset);
+          reset(); // start the initial countdown
+        });
+        return await Promise.race([promise, timeoutPromise]);
+      } finally {
+        rejectFn = null;
+        if (timeoutId !== null) {
+          window.clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+        registerReset(null); // release the reset hook
       }
     }
 
@@ -2209,6 +2254,11 @@
     let jscoqOk = false;
     let rocqBridge = null;
     let rocqBridgeWarmup = null;
+    // Holds the timer-reset callback installed by withActivityTimeout while the
+    // Rocq sync is running; null at all other times.  recordRocqSyncDiagnostic
+    // calls it so that every bridge event (compile:sentence, load_world:*, …)
+    // restarts the inactivity countdown.
+    let rocqSyncActivityReset = null;
     showPlaceholder(
       'Loading JsCoq and game theories…',
       'Fetching the Rocq runtime and the browser-side game theory bundle.'
@@ -2384,9 +2434,16 @@
         beginRocqSyncDiagnostics(selectedMapLabel, rocqSyncWorld);
         let initialSnapshot;
         try {
-          initialSnapshot = await withTimeout(
+          // Use an activity-based timeout so Rocq compilation that emits
+          // compile:sentence events (added in #80) is never killed mid-flight.
+          // Each bridge event (recorded via recordRocqSyncDiagnostic) resets
+          // the countdown; only a full ROCQ_SYNC_TIMEOUT_MS of silence causes
+          // the error — meaning the worker has truly stalled, not just that
+          // the theory takes a while to compile on a slow device.
+          initialSnapshot = await withActivityTimeout(
             rocqBridge.load_world(rocqSyncWorld),
             ROCQ_SYNC_TIMEOUT_MS,
+            fn => { rocqSyncActivityReset = fn; },
             createRocqSyncTimeoutError
           );
           finishRocqSyncDiagnostics('ready');

--- a/docs/index.html
+++ b/docs/index.html
@@ -1497,6 +1497,40 @@
       // This resets the inactivity countdown so slow-but-progressing compilation
       // (e.g. stepping through 2000+ lines of theory) is never killed mid-flight.
       rocqSyncActivityReset?.();
+      // Update the loading overlay detail while the activity timeout is active
+      // (i.e. during load_world / withActivityTimeout).  Before that window the
+      // overlay is showing other phase messages; we leave those alone.
+      if (rocqSyncActivityReset !== null) {
+        updateRocqSyncOverlayProgress(normalized);
+      }
+    }
+
+    // Update the loading overlay detail text in response to bridge events that
+    // arrive while the Rocq sync activity timeout is running:
+    //
+    //   compile:sentence        — theory is still compiling; show per-sentence
+    //                             progress so the user knows Rocq is alive.
+    //   load_world:helpers-ready — compilation finished; restore the canonical
+    //                             "running queries" detail so the overlay is
+    //                             accurate for the query phase that follows.
+    //
+    // Only called while rocqSyncActivityReset is non-null (inside load_world).
+    function updateRocqSyncOverlayProgress(event) {
+      const { stage, payload } = event;
+      if (stage === 'compile:sentence') {
+        const n = payload?.sentenceIndex;
+        if (typeof n === 'number') {
+          placeholderDetail.textContent =
+            `Compiling game-core theory\u2026 ${n} ${n === 1 ? 'sentence' : 'sentences'} done`;
+          placeholderDetail.hidden = false;
+        }
+      } else if (stage === 'load_world:helpers-ready') {
+        // Theory compilation is complete; restore the canonical detail so the
+        // overlay doesn't continue to say "N sentences done" during queries.
+        placeholderDetail.textContent =
+          'Building the initial render snapshot from the verified game core.';
+        placeholderDetail.hidden = false;
+      }
     }
 
     function finishRocqSyncDiagnostics(state) {

--- a/docs/rocq_bridge.js
+++ b/docs/rocq_bridge.js
@@ -304,7 +304,7 @@ async function waitForSentenceProcessed(sentence, sid) {
   }
 }
 
-async function ensureBridgeHelpersReady(manager) {
+async function ensureBridgeHelpersReady(manager, emit) {
   await waitForManagerReady(manager);
 
   let sentence = manager.doc.sentences.find(stm =>
@@ -314,11 +314,19 @@ async function ensureBridgeHelpersReady(manager) {
     return sentence.coq_sid;
   }
 
+  // Step through sentences one at a time, emitting a compile:sentence event
+  // after each one completes.  These events let the activity-based timeout
+  // (see withActivityTimeout in index.html) know that Rocq is still making
+  // forward progress, and give the loading overlay something to display.
+  let sentenceIndex = 0;
   while (manager.goNext(false)) {
     sentence = manager.doc.sentences[manager.doc.sentences.length - 1];
     const sid = await waitForSentenceSid(sentence);
     await waitForSentenceProcessed(sentence, sid);
-    if (sentence.text.includes(BRIDGE_HELPERS_DEFINITION)) {
+    sentenceIndex++;
+    const isTarget = sentence.text.includes(BRIDGE_HELPERS_DEFINITION);
+    emitDiagnostic(emit, 'compile:sentence', { sid, sentenceIndex, isTarget });
+    if (isTarget) {
       return sid;
     }
   }
@@ -380,7 +388,7 @@ export function createRocqBridge(manager, options = {}) {
   });
 
   function getBridgeHelpersSid() {
-    bridgeHelpersSidPromise ||= ensureBridgeHelpersReady(manager);
+    bridgeHelpersSidPromise ||= ensureBridgeHelpersReady(manager, onDiagnostic);
     return bridgeHelpersSidPromise;
   }
 

--- a/scripts/browser-test.mjs
+++ b/scripts/browser-test.mjs
@@ -299,6 +299,125 @@ async function runMissingSentencePromiseRegression() {
   }
 }
 
+async function runCompileSentenceDiagnosticsRegression() {
+  const scenario = 'bridge-compile-sentence-diagnostics-regression';
+
+  try {
+    const { createRocqBridge } =
+      await import(new URL('../docs/rocq_bridge.js', import.meta.url));
+    const diagnostics = [];
+    const queryCalls = [];
+
+    // Three sentences: two non-target, then the target (contains
+    // BRIDGE_HELPERS_DEFINITION).  goNext() adds them one at a time so the
+    // loop in ensureBridgeHelpersReady exercises the compile:sentence path.
+    const sentences = [
+      { text: 'Require Import Foo.',           coq_sid: null, phase: 'processing' },
+      { text: 'Definition bar := 42.',          coq_sid: null, phase: 'processing' },
+      {
+        text: 'Definition step_world_words_in_world := step_world_words_in_world.',
+        coq_sid: null,
+        phase: 'processing',
+      },
+    ];
+    let goNextCallCount = 0;
+
+    const manager = {
+      when_ready: { promise: Promise.resolve() },
+      doc: { sentences: [] },
+      goNext() {
+        if (goNextCallCount >= sentences.length) return false;
+        const sentence = sentences[goNextCallCount];
+        goNextCallCount++;
+        manager.doc.sentences.push(sentence);
+        // coq_sid assigned synchronously; phase transitions after a short delay
+        // so waitForSentenceProcessed has something to poll.
+        sentence.coq_sid = goNextCallCount;
+        const delay = 10 * goNextCallCount;
+        setTimeout(() => { sentence.phase = 'processed'; }, delay);
+        return true;
+      },
+      pprint: { pp2Text(message) { return message; } },
+      coq: {
+        queryPromise(sid, query) {
+          const command = Array.isArray(query) ? String(query[1] ?? '') : String(query ?? '');
+          queryCalls.push({ sid, command });
+          if (command.includes('initial_game_state_words_from_entities')) {
+            return Promise.resolve([
+              { msg: '= [0; 1; 0; 1; 0; 1; 0; 1; 0; 1; 0; 1; 0; 1; 0; 1; 1; 0; 0]' },
+            ]);
+          }
+          if (command.includes('initial_visible_faces_from_inputs')) {
+            return Promise.resolve([{ msg: '= []' }]);
+          }
+          throw new Error(`unexpected Rocq query in regression: ${command}`);
+        },
+      },
+    };
+
+    const bridge = createRocqBridge(manager, {
+      onDiagnostic(event) { diagnostics.push(event); },
+    });
+    const world = {
+      entities: [], faces: [], textures: [], planes: [],
+      models: [], brushes: [], brushSides: [],
+    };
+
+    const snapshot = await withNodeTimeout(
+      bridge.load_world(world),
+      2000,
+      'timed out waiting for load_world during compile-sentence regression'
+    );
+
+    const stages = diagnostics.map(event => event.stage);
+    const compileSentenceEvents = diagnostics.filter(event => event.stage === 'compile:sentence');
+
+    if (compileSentenceEvents.length !== 3) {
+      throw new Error(
+        `expected 3 compile:sentence events, got ${compileSentenceEvents.length}`
+      );
+    }
+
+    for (let i = 0; i < compileSentenceEvents.length; i++) {
+      const { sentenceIndex, isTarget } = compileSentenceEvents[i].payload;
+      if (sentenceIndex !== i + 1) {
+        throw new Error(
+          `compile:sentence[${i}].sentenceIndex should be ${i + 1}, got ${sentenceIndex}`
+        );
+      }
+      const expectedTarget = i === compileSentenceEvents.length - 1;
+      if (isTarget !== expectedTarget) {
+        throw new Error(
+          `compile:sentence[${i}].isTarget should be ${expectedTarget}, got ${isTarget}`
+        );
+      }
+    }
+
+    if (!stages.includes('load_world:helpers-ready')) {
+      throw new Error('compile-sentence regression never reached load_world:helpers-ready');
+    }
+    if (!stages.includes('load_world:complete')) {
+      throw new Error('compile-sentence regression never completed load_world');
+    }
+    if (!Array.isArray(snapshot.visibleFaces)) {
+      throw new Error('compile-sentence regression snapshot did not include visibleFaces');
+    }
+
+    return {
+      scenario,
+      passed: true,
+      details: { diagnostics, compileSentenceEvents, queryCalls },
+    };
+  } catch (error) {
+    return {
+      scenario,
+      passed: false,
+      failure: error.message,
+      stack: error.stack ?? '',
+    };
+  }
+}
+
 async function waitForUrl(url, timeoutMs) {
   const deadline = Date.now() + timeoutMs;
   let lastError = null;
@@ -1838,6 +1957,7 @@ async function main() {
 
     if (!SKIP_LOCAL_SCENARIOS) {
       scenarios.push(await runMissingSentencePromiseRegression());
+      scenarios.push(await runCompileSentenceDiagnosticsRegression());
     }
 
     const scenarioConfigs = [];

--- a/scripts/browser-test.mjs
+++ b/scripts/browser-test.mjs
@@ -147,6 +147,92 @@ export function createRocqBridge(_manager, options = {}) {
 }
 `;
 
+// Bridge that simulates slow theory compilation by emitting compile:sentence
+// events at 100 ms intervals (6 sentences, 600 ms total) before completing.
+// With rocq_sync_timeout_ms=500 a flat withTimeout would fire at 500 ms and
+// kill the load mid-compile; withActivityTimeout resets on every event and
+// lets it finish.  Used by the activity-timeout and progress-overlay tests.
+const SLOW_COMPILE_BRIDGE_SOURCE = `
+const VIEW_MATRIX = [1, 0, 0, 0,
+                     0, 1, 0, 0,
+                     0, 0, 1, 0,
+                     0, 0, 0, 1];
+
+export function createRocqBridge(_manager, options = {}) {
+  let visibleFaces = [];
+  const onDiagnostic =
+    typeof options?.onDiagnostic === 'function' ? options.onDiagnostic : null;
+
+  function emit(stage, payload = {}) {
+    onDiagnostic?.({
+      stage,
+      at: new Date().toISOString(),
+      payload,
+    });
+  }
+
+  function snapshot() {
+    return {
+      position: { x: 0, y: 0, z: 0 },
+      yaw: 0,
+      pitch: 0,
+      visibleFaces: [...visibleFaces],
+      viewMatrix: new Float32Array(VIEW_MATRIX),
+    };
+  }
+
+  return {
+    version: 1,
+
+    async prepare() {},
+
+    async load_world(world) {
+      visibleFaces = Array.isArray(world?.faces)
+        ? world.faces.map((_, fi) => fi)
+        : [];
+      emit('load_world:requested', { faceCount: visibleFaces.length });
+
+      // Simulate six sentences compiling at 100 ms intervals.
+      // Total theory-compile window: 600 ms.  The activity-based timeout
+      // (withActivityTimeout) resets on each compile:sentence event so the
+      // load is never killed mid-compile even with rocq_sync_timeout_ms=500.
+      const SENTENCE_COUNT = 6;
+      for (let i = 1; i <= SENTENCE_COUNT; i++) {
+        await new Promise(resolve => setTimeout(resolve, 100));
+        emit('compile:sentence', {
+          sid: i,
+          sentenceIndex: i,
+          isTarget: i === SENTENCE_COUNT,
+        });
+      }
+
+      const nextSnapshot = snapshot();
+      emit('load_world:helpers-ready', { sid: SENTENCE_COUNT });
+      emit('load_world:received', { sid: SENTENCE_COUNT });
+      emit('load_world:decoded', {
+        gsWordCount: 0,
+        visibleFaceCount: nextSnapshot.visibleFaces.length,
+      });
+      emit('load_world:snapshot_built', {
+        visibleFaceCount: nextSnapshot.visibleFaces.length,
+      });
+      emit('load_world:complete', {
+        visibleFaceCount: nextSnapshot.visibleFaces.length,
+      });
+      return nextSnapshot;
+    },
+
+    async step() {
+      return snapshot();
+    },
+
+    async reset() {
+      return snapshot();
+    },
+  };
+}
+`;
+
 async function withNodeTimeout(promise, timeoutMs, message) {
   let timeoutId = null;
   try {
@@ -508,7 +594,8 @@ async function createScenarioRoot(scenarioName) {
 
   if (scenarioName === 'licensed-map-render-startup' ||
       scenarioName === 'licensed-map-parse-handoff' ||
-      scenarioName === 'rocq-sync-timeout-overlay') {
+      scenarioName === 'rocq-sync-timeout-overlay' ||
+      scenarioName === 'slow-compile-overlay') {
     await fs.mkdir(path.join(rootDir, 'assets', 'maps'), { recursive: true });
     await fs.writeFile(
       path.join(rootDir, 'assets', 'manifest.json'),
@@ -517,11 +604,14 @@ async function createScenarioRoot(scenarioName) {
     await fs.copyFile(LICENSED_MAP_SOURCE, path.join(rootDir, 'assets', LICENSED_MAP_PATH));
   }
 
-  if (scenarioName === 'licensed-map-render-startup' || scenarioName === 'rocq-sync-timeout-overlay') {
-    await fs.writeFile(
-      path.join(rootDir, 'rocq_bridge.js'),
-      scenarioName === 'rocq-sync-timeout-overlay' ? HANGING_BRIDGE_SOURCE : STUB_BRIDGE_SOURCE
-    );
+  if (scenarioName === 'licensed-map-render-startup' ||
+      scenarioName === 'rocq-sync-timeout-overlay' ||
+      scenarioName === 'slow-compile-overlay') {
+    const bridgeSource =
+      scenarioName === 'rocq-sync-timeout-overlay' ? HANGING_BRIDGE_SOURCE :
+      scenarioName === 'slow-compile-overlay'       ? SLOW_COMPILE_BRIDGE_SOURCE :
+                                                      STUB_BRIDGE_SOURCE;
+    await fs.writeFile(path.join(rootDir, 'rocq_bridge.js'), bridgeSource);
   }
 
   return rootDir;
@@ -1661,6 +1751,88 @@ function assertRocqSyncTimeoutScenario(snapshot, consoleEvents, interactions) {
   }
 }
 
+// Asserts that the activity-based Rocq sync timeout did NOT fire prematurely
+// for a slow-but-progressing compilation.  The SLOW_COMPILE_BRIDGE_SOURCE
+// emits 6 compile:sentence events at 100 ms intervals (600 ms total); with
+// rocq_sync_timeout_ms=500 a flat withTimeout would kill it, but
+// withActivityTimeout resets on each event and allows completion.
+function assertRocqSyncActivityTimeoutScenario(snapshot, consoleEvents) {
+  const failure = detectFailure(snapshot, consoleEvents);
+  if (failure) {
+    throw new Error(`activity timeout regression unexpectedly detected failure: ${failure}`);
+  }
+  // Overlay must be hidden — render started, timeout did not fire.
+  if (snapshot.placeholder?.hidden !== true) {
+    throw new Error(
+      `activity timeout: overlay still visible after load_world should have completed — ` +
+      `state=${snapshot.placeholder?.state ?? '(missing)'}, ` +
+      `detail="${snapshot.placeholder?.detail ?? '(empty)'}"`
+    );
+  }
+  // Diagnostics state must be 'ready', not 'timed-out'.
+  if (snapshot.rocqSyncDiagnostics?.state !== 'ready') {
+    throw new Error(
+      `activity timeout: expected rocq sync diagnostics state 'ready', ` +
+      `got '${snapshot.rocqSyncDiagnostics?.state ?? '(missing)'}'`
+    );
+  }
+  // Event history must include at least one compile:sentence event — proves
+  // the events arrived and were recorded (not silently dropped).
+  const events = Array.isArray(snapshot.rocqSyncDiagnostics?.events)
+    ? snapshot.rocqSyncDiagnostics.events
+    : [];
+  if (!events.some(e => e.stage === 'compile:sentence')) {
+    const stages = events.map(e => e.stage).join(', ') || '(none)';
+    throw new Error(
+      `activity timeout: expected compile:sentence events in rocq sync diagnostics, ` +
+      `got: ${stages}`
+    );
+  }
+}
+
+// Asserts that the loading overlay showed per-sentence compilation progress
+// while the SLOW_COMPILE_BRIDGE_SOURCE was compiling theory.  The
+// readyWhen predicate fires as soon as the detail text shows "Compiling
+// game-core theory", so interactions.readySnapshot captures the live state.
+function assertRocqSyncCompileProgressOverlayScenario(snapshot, consoleEvents, interactions) {
+  const failure = detectFailure(snapshot, consoleEvents);
+  if (failure && !failure.startsWith('status-bar-error') && !failure.startsWith('render-startup-failed')) {
+    throw new Error(failure);
+  }
+
+  const progressSnapshot = interactions.readySnapshot;
+  if (!progressSnapshot?.placeholder) {
+    throw new Error('compile progress overlay: readySnapshot is missing the placeholder element');
+  }
+  if (progressSnapshot.placeholder.hidden) {
+    throw new Error(
+      'compile progress overlay: placeholder was hidden when progress text was expected — ' +
+      'compile:sentence events may not be reaching the overlay'
+    );
+  }
+  // Detail must start with the canonical progress prefix.
+  const detail = progressSnapshot.placeholder.detail ?? '';
+  if (!detail.startsWith('Compiling game-core theory')) {
+    throw new Error(
+      `compile progress overlay: expected detail to start with ` +
+      `"Compiling game-core theory", got: "${detail || '(empty)'}"`
+    );
+  }
+  // Detail must end with "sentence done" or "sentences done".
+  if (!detail.includes('sentence') || !detail.includes('done')) {
+    throw new Error(
+      `compile progress overlay: detail missing "sentence … done" progress text, got: "${detail}"`
+    );
+  }
+  // Title must remain "Syncing Rocq render state\u2026" — we only update the detail.
+  if (progressSnapshot.placeholder.title !== 'Syncing Rocq render state\u2026') {
+    throw new Error(
+      `compile progress overlay: title changed unexpectedly during compile progress, ` +
+      `got: "${progressSnapshot.placeholder.title ?? '(empty)'}"`
+    );
+  }
+}
+
 async function dragResizeHandle(page, { deltaX = 0, deltaY = 0 }) {
   const handle = page.locator('#resize-handle');
   const box = await handle.boundingBox();
@@ -2066,6 +2238,39 @@ async function main() {
           },
           assert(snapshot, consoleEvents, interactions) {
             assertRocqSyncTimeoutScenario(snapshot, consoleEvents, interactions);
+          },
+        },
+        {
+          // Regression for the activity-based timeout: SLOW_COMPILE_BRIDGE_SOURCE
+          // emits 6 compile:sentence events at 100 ms intervals (600 ms total).
+          // With rocq_sync_timeout_ms=500 a flat withTimeout would fire at 500 ms
+          // and produce a timeout error; withActivityTimeout resets on each event
+          // and lets load_world complete.  If this scenario fails with a timeout
+          // overlay, withActivityTimeout is broken.
+          name: 'browser-rocq-sync-activity-timeout',
+          rootScenario: 'slow-compile-overlay',
+          query: 'rocq_sync_timeout_ms=500',
+          readyWhen(current) {
+            return current.placeholder?.hidden === true;
+          },
+          assert(snapshot, consoleEvents) {
+            assertRocqSyncActivityTimeoutScenario(snapshot, consoleEvents);
+          },
+        },
+        {
+          // Verifies that the loading overlay detail text updates to show
+          // per-sentence compilation progress while theory is compiling.
+          // readyWhen fires as soon as the detail shows the progress prefix,
+          // giving interactions.readySnapshot the live overlay state.
+          name: 'browser-rocq-sync-compile-progress-overlay',
+          rootScenario: 'slow-compile-overlay',
+          readyWhen(current) {
+            return !current.placeholder?.hidden
+              && typeof current.placeholder?.detail === 'string'
+              && current.placeholder.detail.startsWith('Compiling game-core theory');
+          },
+          assert(snapshot, consoleEvents, interactions) {
+            assertRocqSyncCompileProgressOverlayScenario(snapshot, consoleEvents, interactions);
           },
         }
       );


### PR DESCRIPTION
Fixes #70.

The deployed demo times out because compiling ~2000 lines of Rocq theory from source in-browser via JsCoq WASM can exceed the flat timeout, and the `ensureBridgeHelpersReady` loop emits zero diagnostic events during compilation — so every timeout looks like silent death. This PR adds per-sentence compilation progress events, replaces the flat timeout with an activity-based one that resets on progress, shows compilation progress in the loading overlay, and updates the Playwright suite to cover the new timeout and progress behavior.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] Show Rocq theory compilation progress in the loading overlay <!-- type:spec -->
- [x] Update Playwright tests for progress-aware timeout and compilation events <!-- type:spec -->
- [x] Replace flat Rocq sync timeout with activity-based timeout <!-- type:spec -->
- [x] Emit per-sentence progress diagnostics during Rocq theory compilation <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->