### PR TITLE
CI: always pull Docker image, never rebuild — unblock push (closes #40)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,19 @@ on:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull container image
         run: docker pull ghcr.io/rhencke/orly:latest


### PR DESCRIPTION
Fixes #40.

Add ghcr.io authentication to the CI workflow so `docker pull` succeeds against a private registry, and remove the in-CI Docker image rebuild so the image is built once and pulled on every run.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Add ghcr.io auth to CI pull and remove in-CI Docker rebuild <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->